### PR TITLE
Update benchmark tool docs and implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,19 @@ Expected output:
 mosqueeze v0.1.0
 ```
 
+## Run Benchmark Tool
+
+```bash
+# List engines and levels
+./build/src/mosqueeze-bench/mosqueeze-bench --list-engines
+
+# Benchmark a directory with multiple iterations
+./build/src/mosqueeze-bench/mosqueeze-bench --directory ./benchmarks/corpus --iterations 5 --warmup 2 --summary
+
+# Export HTML report
+./build/src/mosqueeze-bench/mosqueeze-bench --directory ./benchmarks/corpus --export ./benchmarks/results/report.html --format html
+```
+
 ## Run Tests
 
 ```bash
@@ -58,6 +71,7 @@ ctest --output-on-failure
 - [Algorithm Comparison Matrix](docs/wiki/algorithms/comparison-matrix.md) — Which algorithm for which file type
 - [FileType → Algorithm Mapping](docs/wiki/decisions/file-type-to-algorithm.md) — Decision guide
 - [Benchmark Results](docs/wiki/benchmarks/graphs/ratio-by-algorithm.md) — Performance data
+- [Benchmark Tool Guide](docs/wiki/guides/benchmark-tool.md) — Full `mosqueeze-bench` CLI and exports
 - [Getting Started Guide](docs/wiki/guides/getting-started.md) — Full setup instructions
 
 ## License

--- a/docs/features/feat-23-enhanced-benchmark-tool.md
+++ b/docs/features/feat-23-enhanced-benchmark-tool.md
@@ -1,0 +1,828 @@
+# Worker Spec: Enhanced Benchmark Tool (Issue #23)
+
+## Overview
+
+Migliorare `mosqueeze-bench` con CLI avanzato per benchmark intensivi su file arbitrari.
+
+## Stato Attuale
+
+Il tool esistente (`src/mosqueeze-bench/`) ha:
+- ✅ `BenchmarkRunner` con registrazione engine
+- ✅ `run()` con opzioni algoritmi/levels
+- ✅ `runGrid()` per tutti gli algoritmi
+- ✅ `ResultsStore` SQLite con export JSON/CSV
+- ✅ `CorpusManager` per corpus standard
+- ✅ `BenchmarkResult` struct con ratio/encode/decode/memory
+
+**File esistenti:**
+- `src/mosqueeze-bench/src/main.cpp` — CLI entry point
+- `src/mosqueeze-bench/src/BenchmarkRunner.cpp` — Runner implementation
+- `src/mosqueeze-bench/src/CorpusManager.cpp` — Corpus handling
+- `src/mosqueeze-bench/src/ResultsStore.cpp` — SQLite storage
+- `include/mosqueeze/bench/BenchmarkResult.hpp` — Result struct
+
+**Mancano:**
+- ❌ Specifica file arbitrari da CLI (`--file`, `--directory`, `--glob`)
+- ❌ Iterazioni multiple + warmup
+- ❌ Progress callback con output live
+- ❌ Output formattato tabellare
+- ❌ Export Markdown/HTML
+- ❌ Statistiche aggregate (media, deviazione standard)
+- ❌ Time limits per file
+- ❌ Comparison con run precedenti
+
+---
+
+## Parte 1: CLI Options Enhancement
+
+### Nuovi Parametri
+
+```
+mosqueeze-bench [OPTIONS]
+
+Input:
+  -f, --file PATH          Add single file to benchmark
+  -d, --directory PATH     Add all files from directory (recursive)
+  -g, --glob PATTERN       Add files matching glob pattern
+  -c, --corpus PATH        Use standard corpus (default: benchmarks/corpus)
+      --stdin              Read file paths from stdin (one per line)
+
+Algorithm:
+  -a, --algorithms LIST    Comma-separated algorithms (zstd,lzma,brotli,zpaq)
+  -l, --levels LIST        Comma-separated levels (1,5,9,22)
+      --all-engines        Test all registered engines with all levels
+      --default-only       Use only default level for each engine
+
+Benchmark:
+  -i, --iterations N       Number of iterations (default: 1)
+  -w, --warmup N           Warmup iterations excluded from stats (default: 0)
+      --track-memory       Track peak memory usage (default: on)
+      --no-memory          Disable memory tracking
+      --max-time SECONDS   Max time per compression (default: 3600)
+      --decode             Include decompression benchmark (default: on)
+      --no-decode          Skip decompression benchmark
+
+Output:
+  -o, --output DIR         Output directory (default: benchmarks/results)
+      --export FILE        Export results to file
+      --format FORMAT      Export format: json, csv, markdown, html
+  -v, --verbose            Verbose console output with progress
+  -q, --quiet              Quiet mode (errors only)
+      --summary            Print summary table only
+      --no-color           Disable ANSI colors
+
+Comparison:
+      --compare FILE       Compare with previous results (JSON/CSV)
+      --diff-only          Show only files with different results
+
+Misc:
+      --dry-run            Show configuration without running
+      --list-engines       List available engines and their levels
+      --version            Show version
+  -h, --help               Show this help
+```
+
+### Esempi d'Uso
+
+```bash
+# Benchmark singolo file con tutti gli algoritmi
+mosqueeze-bench --file my_video.mkv --all-engines --verbose
+
+# Benchmark directory con iterazioni
+mosqueeze-bench --directory ./data/ --iterations 5 --warmup 2
+
+# Solo ZPAQ su file video
+mosqueeze-bench --glob "*.mkv" --algorithms zpaq --levels 5
+
+# Confronto con run precedente
+mosqueeze-bench --file test.db --compare benchmarks/results/old.json
+
+# Leggi file da stdin
+find . -name "*.json" | mosqueeze-bench --stdin --iterations 3
+```
+
+---
+
+## Parte 2: BenchmarkConfig Struct
+
+### Nuovo Header
+
+`include/mosqueeze/bench/BenchmarkConfig.hpp`:
+
+```cpp
+#pragma once
+
+#include <chrono>
+#include <filesystem>
+#include <functional>
+#include <string>
+#include <vector>
+
+namespace mosqueeze::bench {
+
+struct ProgressInfo {
+    std::filesystem::path currentFile;
+    std::string currentAlgorithm;
+    int currentLevel = 0;
+    int currentIteration = 0;
+    int totalIterations = 0;
+    int totalFiles = 0;
+    int completedFiles = 0;
+    double progress = 0.0;  // 0.0 - 1.0
+};
+
+struct BenchmarkStats {
+    double meanRatio = 0.0;
+    double stdDevRatio = 0.0;
+    double meanEncodeTime = 0.0;
+    double stdDevEncodeTime = 0.0;
+    double meanDecodeTime = 0.0;
+    double stdDevDecodeTime = 0.0;
+    double meanPeakMemory = 0.0;
+    int iterations = 0;
+};
+
+struct BenchmarkConfig {
+    // Input
+    std::vector<std::filesystem::path> files;
+    bool useStdin = false;
+    std::filesystem::path corpusPath{"benchmarks/corpus"};
+    
+    // Algorithms
+    std::vector<std::string> algorithms;
+    std::vector<int> levels;
+    bool allEngines = false;
+    bool defaultOnly = false;
+    
+    // Benchmark
+    int iterations = 1;
+    int warmupIterations = 0;
+    bool trackMemory = true;
+    bool runDecode = true;
+    std::chrono::seconds maxTimePerFile{3600};
+    
+    // Callbacks
+    std::function<void(const ProgressInfo&)> onProgress;
+    std::function<bool()> shouldCancel;  // Return true to cancel
+    
+    // Query methods
+    bool hasProgressCallback() const { return static_cast<bool>(onProgress); }
+    bool hasCancellation() const { return static_cast<bool>(shouldCancel); }
+};
+
+} // namespace mosqueeze::bench
+```
+
+---
+
+## Parte 3: BenchmarkRunner Enhancement
+
+### Aggiornamento Header
+
+`include/mosqueeze/bench/BenchmarkRunner.hpp`:
+
+```cpp
+#pragma once
+
+#include <mosqueeze/ICompressionEngine.hpp>
+#include <mosqueeze/bench/BenchmarkConfig.hpp>
+#include <mosqueeze/bench/BenchmarkResult.hpp>
+
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace mosqueeze::bench {
+
+class BenchmarkRunner {
+public:
+    BenchmarkRunner();
+    ~BenchmarkRunner();
+
+    // Engine management
+    void registerEngine(std::unique_ptr<ICompressionEngine> engine);
+    std::vector<std::string> availableAlgorithms() const;
+    std::vector<int> availableLevels(const std::string& algorithm) const;
+    
+    // Legacy API (backward compatible)
+    std::vector<BenchmarkResult> run(
+        const std::vector<std::filesystem::path>& files,
+        const std::vector<std::string>& algorithms = {},
+        const std::vector<int>& levels = {});
+
+    std::vector<BenchmarkResult> runGrid(
+        const std::vector<std::filesystem::path>& files);
+    
+    // New API with config
+    std::vector<BenchmarkResult> runWithConfig(const BenchmarkConfig& config);
+    
+    // Statistics
+    std::unordered_map<std::string, BenchmarkStats> computeStats(
+        const std::vector<BenchmarkResult>& results) const;
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> impl_;
+    
+    ICompressionEngine* findEngine(const std::string& name) const;
+    void runIteration(
+        ICompressionEngine* engine,
+        const std::filesystem::path& file,
+        int level,
+        const CompressionOptions& opts,
+        BenchmarkResult& result);
+};
+
+} // namespace mosqueeze::bench
+```
+
+### Implementation Key Methods
+
+```cpp
+std::vector<BenchmarkResult> BenchmarkRunner::runWithConfig(const BenchmarkConfig& config) {
+    if (engines_.empty()) {
+        throw std::runtime_error("No engines registered");
+    }
+    
+    // Select engines
+    std::vector<ICompressionEngine*> selectedEngines;
+    if (config.allEngines || config.algorithms.empty()) {
+        for (const auto& e : engines_) {
+            selectedEngines.push_back(e.get());
+        }
+    } else {
+        for (const auto& name : config.algorithms) {
+            auto* engine = findEngine(name);
+            if (engine) selectedEngines.push_back(engine);
+        }
+    }
+    
+    FileTypeDetector detector;
+    std::vector<BenchmarkResult> allResults;
+    
+    int totalWork = config.files.size() * selectedEngines.size() 
+                  * config.iterations * levels.size();
+    int completedWork = 0;
+    
+    for (const auto& file : config.files) {
+        // Check cancellation
+        if (config.hasCancellation() && config.shouldCancel()) {
+            break;
+        }
+        
+        auto classification = detector.detect(file);
+        
+        for (ICompressionEngine* engine : selectedEngines) {
+            std::vector<int> levelsToTest;
+            if (config.defaultOnly) {
+                levelsToTest.push_back(engine->defaultLevel());
+            } else if (config.levels.empty()) {
+                levelsToTest = engine->supportedLevels();
+            } else {
+                // Filter levels to supported ones
+                auto supported = engine->supportedLevels();
+                for (int l : config.levels) {
+                    if (std::find(supported.begin(), supported.end(), l) != supported.end()) {
+                        levelsToTest.push_back(l);
+                    }
+                }
+            }
+            
+            for (int level : levelsToTest) {
+                // Warmup iterations
+                for (int w = 0; w < config.warmupIterations; ++w) {
+                    BenchmarkResult dummy;
+                    runIteration(engine, file, level, CompressionOptions{}, dummy);
+                    
+                    if (config.hasProgressCallback()) {
+                        ProgressInfo info{};
+                        info.currentFile = file;
+                        info.currentAlgorithm = engine->name();
+                        info.currentLevel = level;
+                        info.currentIteration = w;
+                        info.totalIterations = config.warmupIterations + config.iterations;
+                        info.progress = static_cast<double>(completedWork) / totalWork;
+                        config.onProgress(info);
+                    }
+                    ++completedWork;
+                }
+                
+                // Measured iterations
+                for (int iter = 0; iter < config.iterations; ++iter) {
+                    BenchmarkResult result;
+                    runIteration(engine, file, level, CompressionOptions{}, result);
+                    result.fileType = classification.type;
+                    allResults.push_back(result);
+                    
+                    if (config.hasProgressCallback()) {
+                        ProgressInfo info{};
+                        info.currentFile = file;
+                        info.currentAlgorithm = engine->name();
+                        info.currentLevel = level;
+                        info.currentIteration = config.warmupIterations + iter;
+                        info.totalIterations = config.warmupIterations + config.iterations;
+                        info.completedFiles = completedWork / (levelsToTest.size() * selectedEngines.size());
+                        info.totalFiles = config.files.size();
+                        info.progress = static_cast<double>(completedWork) / totalWork;
+                        config.onProgress(info);
+                    }
+                    ++completedWork;
+                }
+            }
+        }
+    }
+    
+    return allResults;
+}
+
+void BenchmarkRunner::runIteration(
+    ICompressionEngine* engine,
+    const std::filesystem::path& file,
+    int level,
+    const CompressionOptions& opts,
+    BenchmarkResult& result) {
+    
+    std::ifstream in(file, std::ios::binary);
+    if (!in) {
+        throw std::runtime_error("Cannot open file: " + file.string());
+    }
+    
+    CompressionOptions optsCopy = opts;
+    optsCopy.level = level;
+    optsCopy.extreme = (level == engine->maxLevel());
+    
+    std::ostringstream compressed;
+    auto encodeStart = std::chrono::steady_clock::now();
+    CompressionResult encodeResult = engine->compress(in, compressed, optsCopy);
+    auto encodeEnd = std::chrono::steady_clock::now();
+    
+    result.algorithm = engine->name();
+    result.level = level;
+    result.file = file;
+    result.originalBytes = encodeResult.originalBytes;
+    result.compressedBytes = encodeResult.compressedBytes;
+    result.encodeTime = std::chrono::duration_cast<std::chrono::milliseconds>(encodeEnd - encodeStart);
+    result.peakMemoryBytes = encodeResult.peakMemoryBytes;
+    
+    // Decode if requested
+    // ... (decompression timing)
+}
+
+std::unordered_map<std::string, BenchmarkStats> BenchmarkRunner::computeStats(
+    const std::vector<BenchmarkResult>& results) const {
+    
+    // Group by algorithm/level
+    std::unordered_map<std::string, std::vector<BenchmarkResult>> grouped;
+    for (const auto& r : results) {
+        std::string key = r.algorithm + "/" + std::to_string(r.level);
+        grouped[key].push_back(r);
+    }
+    
+    std::unordered_map<std::string, BenchmarkStats> stats;
+    for (const auto& [key, values] : grouped) {
+        BenchmarkStats s;
+        s.iterations = values.size();
+        
+        // Compute mean
+        double sumRatio = 0, sumEncode = 0, sumDecode = 0;
+        for (const auto& v : values) {
+            sumRatio += v.ratio();
+            sumEncode += v.encodeTime.count();
+            sumDecode += v.decodeTime.count();
+        }
+        s.meanRatio = sumRatio / values.size();
+        s.meanEncodeTime = sumEncode / values.size();
+        s.meanDecodeTime = sumDecode / values.size();
+        
+        // Compute std dev
+        double varRatio = 0, varEncode = 0;
+        for (const auto& v : values) {
+            varRatio += (v.ratio() - s.meanRatio) * (v.ratio() - s.meanRatio);
+            varEncode += (v.encodeTime.count() - s.meanEncodeTime) 
+                       * (v.encodeTime.count() - s.meanEncodeTime);
+        }
+        s.stdDevRatio = std::sqrt(varRatio / values.size());
+        s.stdDevEncodeTime = std::sqrt(varEncode / values.size());
+        
+        stats[key] = s;
+    }
+    
+    return stats;
+}
+```
+
+---
+
+## Parte 4: Output Formatters
+
+### Console Output (verboso)
+
+```cpp
+// In src/mosqueeze-bench/src/ConsoleFormatter.cpp
+
+std::string formatVerbose(const BenchmarkResult& result, const BenchmarkStats* stats = nullptr) {
+    std::ostringstream out;
+    
+    // File header
+    out << "\n═══════════════════════════════════════════════════════════\n";
+    out << result.file.filename().string() << " (" << formatBytes(result.originalBytes) << ")";
+    out << " - " << fileTypeToString(result.fileType) << "\n";
+    out << "═══════════════════════════════════════════════════════════\n\n";
+    
+    // Algorithm results
+    out << "Algorithm    Level    Ratio    Encode    Decode    Memory\n";
+    out << "─────────────────────────────────────────────────────────────\n";
+    
+    out << std::left << std::setw(12) << result.algorithm;
+    out << std::setw(8) << result.level;
+    out << std::setw(9) << std::fixed << std::setprecision(2) << result.ratio() << "x";
+    out << std::setw(9) << formatDuration(result.encodeTime);
+    out << std::setw(9) << formatDuration(result.decodeTime);
+    out << std::setw(10) << formatBytes(result.peakMemoryBytes);
+    out << "\n";
+    
+    if (stats) {
+        out << "\n  Stats (n=" << stats->iterations << "):\n";
+        out << "    Ratio: " << stats->meanRatio << "x ± " << stats->stdDevRatio << "\n";
+        out << "    Encode: " << stats->meanEncodeTime << "ms ± " << stats->stdDevEncodeTime << "\n";
+    }
+    
+    return out.str();
+}
+```
+
+### Markdown Export
+
+```cpp
+std::string exportMarkdown(const std::vector<BenchmarkResult>& results) {
+    std::ostringstream out;
+    
+    out << "# Benchmark Results\n\n";
+    out << "## Summary\n\n";
+    
+    // Group by file
+    std::map<std::filesystem::path, std::vector<BenchmarkResult>> byFile;
+    for (const auto& r : results) {
+        byFile[r.file].push_back(r);
+    }
+    
+    for (const auto& [file, fileResults] : byFile) {
+        out << "### " << file.filename().string() << "\n\n";
+        out << "| Algorithm | Level | Ratio | Encode | Decode | Memory |\n";
+        out << "|-----------|-------|-------|--------|--------|--------|\n";
+        
+        // Sort by ratio descending
+        auto sorted = fileResults;
+        std::sort(sorted.begin(), sorted.end(), [](const auto& a, const auto& b) {
+            return a.ratio() > b.ratio();
+        });
+        
+        for (const auto& r : sorted) {
+            out << "| " << r.algorithm << " | " << r.level << " | ";
+            out << std::fixed << std::setprecision(2) << r.ratio() << "x | ";
+            out << r.encodeTime.count() << "ms | ";
+            out << r.decodeTime.count() << "ms | ";
+            out << formatBytes(r.peakMemoryBytes) << " |\n";
+        }
+        
+        out << "\n**Best:** " << sorted.front().algorithm << "/" << sorted.front().level << "\n\n";
+    }
+    
+    return out.str();
+}
+```
+
+### HTML Export with Charts
+
+```cpp
+std::string exportHtml(const std::vector<BenchmarkResult>& results) {
+    std::ostringstream out;
+    
+    out << R"(<!DOCTYPE html>
+<html>
+<head>
+    <title>MoSqueeze Benchmark Results</title>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <style>
+        body { font-family: system-ui, sans-serif; margin: 40px; }
+        table { border-collapse: collapse; width: 100%; }
+        th, td { border: 1px solid #ddd; padding: 8px; text-align: left; }
+        th { background: #444; color: white; }
+        tr:nth-child(even) { background: #f8f8f8; }
+        .best { background: #d4edda; }
+    </style>
+</head>
+<body>
+    <h1>MoSqueeze Benchmark Results</h1>
+)";
+
+    // Charts and tables...
+    
+    out << "</body></html>";
+    return out.str();
+}
+```
+
+---
+
+## Parte 5: CLI Implementation
+
+### main.cpp Enhancement
+
+```cpp
+#include <mosqueeze/bench/BenchmarkRunner.hpp>
+#include <mosqueeze/bench/BenchmarkConfig.hpp>
+#include <mosqueeze/bench/CorpusManager.hpp>
+#include <mosqueeze/bench/ResultsStore.hpp>
+#include <mosqueeze/bench/Formatters.hpp>
+
+#include <mosqueeze/engines/ZstdEngine.hpp>
+#include <mosqueeze/engines/LzmaEngine.hpp>
+#include <mosqueeze/engines/BrotliEngine.hpp>
+#include <mosqueeze/engines/ZpaqEngine.hpp>
+
+#include <CLI/CLI.hpp>
+#include <filesystem>
+#include <iostream>
+#include <fstream>
+
+int main(int argc, char* argv[]) {
+    CLI::App app{"MoSqueeze Benchmark Tool", "mosqueeze-bench"};
+    
+    // --- Input options ---
+    std::vector<std::filesystem::path> files;
+    std::filesystem::path directory;
+    std::string globPattern;
+    bool useStdin = false;
+    
+    auto* fileOpt = app.add_option("-f,--file", files, "Files to benchmark");
+    app.add_option("-d,--directory", directory, "Directory to benchmark (recursive)");
+    app.add_option("-g,--glob", globPattern, "Glob pattern for files");
+    app.add_flag("--stdin", useStdin, "Read file paths from stdin");
+    
+    // --- Algorithm options ---
+    std::string algorithmsOpt;
+    std::string levelsOpt;
+    bool allEngines = false;
+    bool defaultOnly = false;
+    
+    app.add_option("-a,--algorithms", algorithmsOpt, "Comma-separated algorithms");
+    app.add_option("-l,--levels", levelsOpt, "Comma-separated levels");
+    app.add_flag("--all-engines", allEngines, "Test all registered engines");
+    app.add_flag("--default-only", defaultOnly, "Use default level only");
+    
+    // --- Benchmark options ---
+    int iterations = 1;
+    int warmup = 0;
+    bool trackMemory = true;
+    int maxTime = 3600;
+    
+    app.add_option("-i,--iterations", iterations, "Number of iterations", true);
+    app.add_option("-w,--warmup", warmup, "Warmup iterations", true);
+    app.add_flag("--track-memory", trackMemory, "Track memory (default: on)");
+    app.add_option("--max-time", maxTime, "Max time per file (seconds)", true);
+    
+    // --- Output options ---
+    std::filesystem::path outputDir{"benchmarks/results"};
+    std::filesystem::path exportFile;
+    std::string format = "json";
+    bool verbose = false;
+    bool quiet = false;
+    bool summary = false;
+    
+    app.add_option("-o,--output", outputDir, "Output directory", true);
+    app.add_option("--export", exportFile, "Export results to file");
+    app.add_option("--format", format, "Export format", true)->check([](const std::string& s) {
+        return (s == "json" || s == "csv" || s == "markdown" || s == "html") 
+            ? "" : "Format must be json, csv, markdown, or html";
+    });
+    app.add_flag("-v,--verbose", verbose, "Verbose output");
+    app.add_flag("-q,--quiet", quiet, "Quiet mode");
+    app.add_flag("--summary", summary, "Summary only");
+    
+    // --- Misc options ---
+    bool dryRun = false;
+    bool listEngines = false;
+    
+    app.add_flag("--dry-run", dryRun, "Show configuration without running");
+    app.add_flag("--list-engines", listEngines, "List available engines");
+    
+    CLI11_PARSE(app, argc, argv);
+    
+    // --- List engines ---
+    if (listEngines) {
+        std::cout << "Available engines:\n";
+        // ... register engines and list
+        return 0;
+    }
+    
+    // --- Build config ---
+    BenchmarkConfig config;
+    
+    // Parse files
+    if (!directory.empty()) {
+        for (auto& entry : std::filesystem::recursive_directory_iterator(directory)) {
+            if (entry.is_regular_file()) {
+                config.files.push_back(entry.path());
+            }
+        }
+    }
+    
+    if (!globPattern.empty()) {
+        // Use std::filesystem with glob
+        // ...
+    }
+    
+    config.files = files;
+    config.allEngines = allEngines;
+    config.defaultOnly = defaultOnly;
+    config.iterations = iterations;
+    config.warmupIterations = warmup;
+    config.trackMemory = trackMemory;
+    config.maxTimePerFile = std::chrono::seconds(maxTime);
+    
+    // Parse algorithms
+    if (!algorithmsOpt.empty()) {
+        std::stringstream ss(algorithmsOpt);
+        std::string token;
+        while (std::getline(ss, token, ',')) {
+            config.algorithms.push_back(token);
+        }
+    }
+    
+    // Parse levels
+    if (!levelsOpt.empty()) {
+        std::stringstream ss(levelsOpt);
+        std::string token;
+        while (std::getline(ss, token, ',')) {
+            config.levels.push_back(std::stoi(token));
+        }
+    }
+    
+    // --- Dry run ---
+    if (dryRun) {
+        std::cout << "Configuration:\n";
+        std::cout << "  Files: " << config.files.size() << "\n";
+        std::cout << "  Algorithms: " << (config.algorithms.empty() ? "(all)" : "") << "\n";
+        std::cout << "  Iterations: " << config.iterations << "\n";
+        std::cout << "  Warmup: " << config.warmupIterations << "\n";
+        return 0;
+    }
+    
+    // --- Progress callback ---
+    if (verbose) {
+        config.onProgress = [](const ProgressInfo& info) {
+            std::cout << "\r[" << info.currentAlgorithm << "/" << info.currentLevel 
+                      << "] " << info.currentFile.filename().string()
+                      << " (" << std::fixed << std::setprecision(1) << (info.progress * 100) << "%)"
+                      << std::flush;
+        };
+    }
+    
+    // --- Run benchmark ---
+    BenchmarkRunner runner;
+    runner.registerEngine(std::make_unique<ZstdEngine>());
+    runner.registerEngine(std::make_unique<LzmaEngine>());
+    runner.registerEngine(std::make_unique<BrotliEngine>());
+    runner.registerEngine(std::make_unique<ZpaqEngine>());
+    
+    auto results = runner.runWithConfig(config);
+    auto stats = runner.computeStats(results);
+    
+    // --- Output ---
+    std::filesystem::create_directories(outputDir);
+    ResultsStore store((outputDir / "results.sqlite3"));
+    store.clear();
+    store.saveAll(results);
+    
+    if (!exportFile.empty()) {
+        if (format == "json") {
+            store.exportJson(exportFile);
+        } else if (format == "csv") {
+            store.exportCsv(exportFile);
+        } else if (format == "markdown") {
+            std::ofstream out(exportFile);
+            out << Formatters::exportMarkdown(results);
+        } else if (format == "html") {
+            std::ofstream out(exportFile);
+            out << Formatters::exportHtml(results);
+        }
+    }
+    
+    // --- Print summary ---
+    if (!quiet) {
+        std::cout << "\n\n=== Best Results ===\n";
+        // Sort and print top results
+    }
+    
+    return 0;
+}
+```
+
+---
+
+## Parte 6: Test
+
+### tests/unit/BenchmarkConfig_test.cpp
+
+```cpp
+#include <mosqueeze/bench/BenchmarkConfig.hpp>
+#include <mosqueeze/bench/BenchmarkRunner.hpp>
+
+#include <cassert>
+#include <iostream>
+
+int main() {
+    mosqueeze::bench::BenchmarkConfig config;
+    
+    // Test defaults
+    assert(config.iterations == 1);
+    assert(config.warmupIterations == 0);
+    assert(config.trackMemory == true);
+    assert(config.maxTimePerFile.count() == 3600);
+    
+    // Test file addition
+    config.files.push_back("/tmp/test.bin");
+    assert(config.files.size() == 1);
+    
+    // Test progress callback
+    bool progressCalled = false;
+    config.onProgress = [&](const mosqueeze::bench::ProgressInfo& info) {
+        progressCalled = true;
+        assert(!info.currentFile.empty());
+    };
+    
+    config.onProgress({});  // Test callback
+    assert(progressCalled);
+    
+    std::cout << "[PASS] BenchmarkConfig tests\n";
+    return 0;
+}
+```
+
+### tests/integration/BenchmarkTool_test.cpp
+
+```cpp
+// Integration test with real files
+// Requires test fixtures in tests/fixtures/
+```
+
+---
+
+## Definizione di Fatto
+
+- [ ] `BenchmarkConfig.hpp` con struct completo
+- [ ] `BenchmarkRunner::runWithConfig()` implementata
+- [ ] Progress callback funzionante
+- [ ] Warmup iterations supportate
+- [ ] CLI con `--file`, `--directory`, `--glob`, `--stdin`
+- [ ] CLI con `--algorithms`, `--levels`, `--all-engines`, `--default-only`
+- [ ] CLI con `--iterations`, `--warmup`
+- [ ] Console output verboso
+- [ ] Export Markdown
+- [ ] Export HTML con charts (Chart.js o Plotly)
+- [ ] `computeStats()` con media e std dev
+- [ ] `--list-engines` funzionante
+- [ ] `--dry-run` funzionante
+- [ ] Test unitari per BenchmarkConfig
+- [ ] CI passa su Linux, macOS, Windows
+
+---
+
+## File da Creare/Modificare
+
+### Nuovi File
+
+1. `src/libmosqueeze/include/mosqueeze/bench/BenchmarkConfig.hpp`
+2. `src/mosqueeze-bench/src/Formatters.cpp`
+3. `src/mosqueeze-bench/include/mosqueeze/bench/Formatters.hpp`
+4. `tests/unit/BenchmarkConfig_test.cpp`
+
+### File da Modificare
+
+5. `src/mosqueeze-bench/include/mosqueeze/bench/BenchmarkRunner.hpp` — aggiungere `runWithConfig`, `computeStats`
+6. `src/mosqueeze-bench/src/BenchmarkRunner.cpp` — implementazione
+7. `src/mosqueeze-bench/src/main.cpp` — nuovo CLI
+8. `src/mosqueeze-bench/CMakeLists.txt` — aggioranre sorgenti
+9. `src/libmosqueeze/CMakeLists.txt` — aggiungere `BenchmarkConfig.hpp`
+
+---
+
+## Note Tecniche
+
+1. **Backward Compatibility**: Mantenere `run()` e `runGrid()` API esistenti
+2. **Memory Tracking**: `platform::getPeakMemoryUsage()` già implementato
+3. **Cancellation**: Usare `std::atomic<bool>` per thread-safety
+4. **Progress Rate limiting**: Non chiamare callback più di 10 volte al secondo
+5. **Large Files**: Gestire file >2GB con streaming (già supportato dagli engine)
+
+---
+
+## Collegamenti
+
+- Issue #2 (Benchmark Harness) — implementazione iniziale
+- Issue #9 (LZMA/Brotli) — engine aggiunti
+- Issue #10 (ZPAQ) — engine aggiunto
+- Issue #21 (Video Support) — test su video

--- a/docs/wiki/benchmarks/methodology.md
+++ b/docs/wiki/benchmarks/methodology.md
@@ -1,6 +1,6 @@
 # Benchmark Methodology
 
-**Summary**: Come vengono eseguiti i benchmark in MoSqueeze.
+**Summary**: How MoSqueeze benchmark runs are executed with the enhanced `mosqueeze-bench` tool.
 
 **Last updated**: 2026-04-22
 
@@ -8,203 +8,113 @@
 
 ## Overview
 
-MoSqueeze usa un benchmark harness per generare dati comparativi reali tra algoritmi.
+MoSqueeze uses `mosqueeze-bench` to generate comparable measurements across engines and levels.
 
-### Tool
+Example:
 
 ```bash
-mosqueeze-bench --corpus corpus/ --output results/
+mosqueeze-bench --directory ./corpus --iterations 5 --warmup 2 --output benchmarks/results
 ```
 
 ---
 
-## Misurazioni
-
-### Metriche Primary
+## Measured Metrics
 
 | Metric | Unit | Description |
 |--------|------|-------------|
-| **Ratio** | factor | `originalBytes / compressedBytes` |
-| **Encode Time** | ms | Tempo di compressione |
-| **Decode Time** | ms | Tempo di decompressione |
-| **Peak Memory** | bytes | Memoria massima usata |
+| Ratio | factor | `originalBytes / compressedBytes` |
+| Encode Time | ms | Compression duration |
+| Decode Time | ms | Decompression duration (optional) |
+| Peak Memory | bytes | Peak memory from engine result (optional) |
 
-### Metriche Derivate
+Derived values:
 
-- **Throughput**: `originalBytes / encodeTime` (MB/s)
-- **Space Savings**: `(1 - 1/ratio) * 100` (%)
-
----
-
-## Corpus
-
-### Standard Corpus Structure
-
-```
-corpus/
-├── text/
-│   ├── code/         # .cpp, .py, .js, .ts, .rs
-│   ├── json/         # Large JSON datasets
-│   ├── xml/          # RSS, SOAP, configs
-│   ├── logs/         # Server logs, app logs
-│   └── markdown/     # README, docs
-├── binary/
-│   ├── exec/         # ELF, PE executables
-│   ├── database/     # SQLite, MDB
-│   └── data/         # Custom binary formats
-├── image/
-│   ├── png/          # Unoptimized PNGs
-│   └── raw/          # BMP, TIFF
-└── archive/
-    └── tar/          # Plain tar files
-```
-
-### Selection Criteria
-
-1. **Rappresentatività** — File tipici per caso d'uso reale
-2. **Dimensione variabile** — Da KB a GB
-3. **Content diversity** — Testo, binario, mixed
-4. **Openness** — Nessun copyright issue
-
-### Files Correnti
-
-```
-# Generati o scaricati per test
-corpus/text/code/
-├── large.cpp         # 2.1 MB C++ source
-├── bundle.js         # 5.8 MB minified JS
-└── kernel_sources/   # 15 MB Linux kernel subset
-
-corpus/text/json/
-├── large_dataset.json  # 5.2 MB JSON
-└── twitter_sample.json # 12 MB tweets
-
-corpus/binary/exec/
-├── test_binary.exe    # 8 MB
-└── libsomething.so    # 4 MB
-```
+- Throughput: `originalBytes / encodeTime`
+- Space savings: `(1 - 1/ratio) * 100`
 
 ---
 
-## Execution
+## Execution Model
 
-### Grid Search
+For each selected file:
 
-Per ogni file, testiamo tutti gli algoritmi × tutti i livelli:
+1. Select engines (`--algorithms` or `--all-engines`)
+2. Select levels (`--levels`, `--default-only`, or engine defaults)
+3. Run warmup iterations (`--warmup`)
+4. Run measured iterations (`--iterations`)
+5. Record result rows per measured run
 
-```python
-algorithms = ['zstd', 'lzma', 'brotli']
-levels = {
-    'zstd': [3, 10, 19, 22],
-    'lzma': [3, 6, 9],
-    'brotli': [6, 9, 11]
-}
+Runtime controls:
 
-for file in corpus:
-    for algo in algorithms:
-        for level in levels[algo]:
-            run_benchmark(file, algo, level)
-```
-
-### Controls
-
-- **Cold runs**: 3x per stabilità statistiche
-- **Memory isolation**: Ogni run fresh process
-- **CPU isolation**: Affinity pinning quando possibile
-- **Timing**: `std::chrono::steady_clock` high resolution
+- `--max-time` for per-step timeout guard
+- `--no-decode` to skip decode benchmark
+- `--no-memory` to disable memory field capture
+- `--verbose` for progress callback output
 
 ---
 
-## Results Storage
+## Statistics
 
-### SQLite Schema
+`BenchmarkRunner::computeStats(...)` aggregates results by `algorithm/level`:
 
-```sql
-CREATE TABLE benchmark_results (
-    id INTEGER PRIMARY KEY,
-    timestamp TEXT,
-    algorithm TEXT,
-    level INTEGER,
-    file_path TEXT,
-    file_type TEXT,
-    original_bytes INTEGER,
-    compressed_bytes INTEGER,
-    encode_time_ms INTEGER,
-    decode_time_ms INTEGER,
-    peak_memory_bytes INTEGER
-);
-```
+- mean ratio + stddev ratio
+- mean encode time + stddev encode time
+- mean decode time + stddev decode time
+- mean peak memory
+- sample count (`iterations`)
 
-### JSON Export
+---
+
+## Result Storage and Exports
+
+Default output directory: `benchmarks/results`
+
+- SQLite database: `results.sqlite3`
+- Default exports (if `--export` is not set):
+  - `results.json`
+  - `results.csv`
+- Explicit exports:
+  - `--format json`
+  - `--format csv`
+  - `--format markdown`
+  - `--format html`
+
+JSON export format is an array of rows:
 
 ```json
-{
-  "timestamp": "2026-04-22T15:30:00Z",
-  "results": [
-    {
-      "algorithm": "zstd",
-      "level": 19,
-      "file": "corpus/text/code/large.cpp",
-      "fileType": "Text_SourceCode",
-      "originalBytes": 2100000,
-      "compressedBytes": 540000,
-      "encodeTimeMs": 1200,
-      "decodeTimeMs": 45,
-      "peakMemoryBytes": 134000000
-    }
-  ]
-}
+[
+  {
+    "algorithm": "zstd",
+    "level": 19,
+    "file": "corpus/text/code/large.cpp",
+    "fileType": 1,
+    "originalBytes": 2100000,
+    "compressedBytes": 540000,
+    "encodeMs": 1200,
+    "decodeMs": 45,
+    "peakMemoryBytes": 134000000,
+    "ratio": 3.89
+  }
+]
 ```
 
 ---
 
-## Reproducibility
+## Comparison Runs
 
-### Hash Verification
+You can compare current results against previous exports:
 
 ```bash
-# Calcolato pre-compressione
-sha256sum corpus/file.txt > corpus/file.txt.sha256
+mosqueeze-bench --directory ./corpus --compare ./benchmarks/results/previous.json
+mosqueeze-bench --directory ./corpus --compare ./benchmarks/results/previous.csv --diff-only
 ```
 
-### Environment Recording
-
-```json
-{
-  "environment": {
-    "os": "Ubuntu 22.04",
-    "cpu": "AMD Ryzen 9 5900X",
-    "memory": "64 GB DDR4",
-    "compiler": "GCC 12.2",
-    "zstd_version": "1.5.5",
-    "lzma_version": "5.4.1",
-    "brotli_version": "1.0.9"
-  }
-}
-```
-
----
-
-## Analysis
-
-### Reporting
-
-Dopo ogni run:
-1. Export JSON + CSV
-2. Generate graphs (scripts/generate_graphs.py)
-3. Update wiki con risultati notevoli
-
-### Comparison
-
-Si possono confrontare run diverse:
-- Tra versioni MoSqueeze
-- Tra hardware diversi
-- Tempo evoluzione (regression detection)
+Comparison grouping key: `file + algorithm + level`.
 
 ---
 
 ## Related Pages
 
-- [[corpus-selection]] — Dettagli sui file di test
-- [[graphs/ratio-by-algorithm]] — Grafici risultati
-- [[results/index]] — Risultati storici
+- [[corpus-selection]] - Test corpus criteria
+- [[results/index]] - Historical benchmark archive
+- [[../guides/benchmark-tool]] - Full CLI guide

--- a/docs/wiki/guides/benchmark-tool.md
+++ b/docs/wiki/guides/benchmark-tool.md
@@ -1,0 +1,140 @@
+# Benchmark Tool (`mosqueeze-bench`)
+
+**Summary**: Practical guide for the enhanced benchmark CLI implemented in Issue #23.
+
+**Last updated**: 2026-04-22
+
+---
+
+## Overview
+
+`mosqueeze-bench` supports:
+
+- arbitrary input selection (`--file`, `--directory`, `--glob`, `--stdin`)
+- engine/level selection (`--algorithms`, `--levels`, `--all-engines`, `--default-only`)
+- repeated runs with warmup (`--iterations`, `--warmup`)
+- optional decode and memory tracking (`--no-decode`, `--no-memory`)
+- progress callback in verbose mode (`--verbose`)
+- result exports (`json`, `csv`, `markdown`, `html`)
+- previous run comparison (`--compare`, `--diff-only`)
+
+---
+
+## Basic Usage
+
+```bash
+# Run on standard corpus fallback
+./mosqueeze-bench
+
+# Single file, all engines, verbose progress
+./mosqueeze-bench --file ./data/sample.db --all-engines --verbose
+
+# Recursive directory with repeatability controls
+./mosqueeze-bench --directory ./datasets --iterations 5 --warmup 2
+
+# Glob with selected algorithm and level
+./mosqueeze-bench --glob "*.mkv" --algorithms zpaq --levels 5
+```
+
+---
+
+## Input Modes
+
+```bash
+# Add multiple files
+./mosqueeze-bench --file a.bin --file b.json
+
+# Read file list from stdin (one path per line)
+find ./data -name "*.json" | ./mosqueeze-bench --stdin --iterations 3
+```
+
+If no explicit files are provided, the tool uses `--corpus` (default `benchmarks/corpus`).
+
+---
+
+## CLI Options
+
+```text
+Input:
+  -f, --file PATH
+  -d, --directory PATH
+  -g, --glob PATTERN
+  -c, --corpus PATH
+      --stdin
+
+Algorithm:
+  -a, --algorithms LIST
+  -l, --levels LIST
+      --all-engines
+      --default-only
+
+Benchmark:
+  -i, --iterations N
+  -w, --warmup N
+      --track-memory
+      --no-memory
+      --max-time SECONDS
+      --decode
+      --no-decode
+
+Output:
+  -o, --output DIR
+      --export FILE
+      --format FORMAT      (json|csv|markdown|html)
+  -v, --verbose
+  -q, --quiet
+      --summary
+      --no-color
+
+Comparison:
+      --compare FILE
+      --diff-only
+
+Misc:
+      --dry-run
+      --list-engines
+      --version
+```
+
+---
+
+## Output and Storage
+
+- SQLite store: `benchmarks/results/results.sqlite3` (or `--output`)
+- Auto-export defaults (when `--export` is not provided):
+  - `results.json`
+  - `results.csv`
+- Optional manual export:
+  - `--format markdown` for report-friendly tables
+  - `--format html` for browser report + chart
+
+---
+
+## Comparison Workflow
+
+```bash
+# Compare against a previous JSON export
+./mosqueeze-bench --directory ./data --compare ./benchmarks/results/old.json
+
+# Show only changed entries
+./mosqueeze-bench --directory ./data --compare ./benchmarks/results/old.csv --diff-only
+```
+
+Comparison keys are grouped by `file + algorithm + level`.
+
+---
+
+## Implementation Notes
+
+- `BenchmarkRunner::runWithConfig(...)` is the primary execution path.
+- Legacy `run()` and `runGrid()` remain supported.
+- Progress callbacks are rate-limited to avoid console flooding.
+- `computeStats(...)` returns aggregated means and standard deviations grouped by `algorithm/level`.
+
+---
+
+## Related Pages
+
+- [[../benchmarks/methodology]] - Measurement methodology
+- [[getting-started]] - Build and run basics
+- [[../benchmarks/results/index]] - Historical run index

--- a/docs/wiki/guides/getting-started.md
+++ b/docs/wiki/guides/getting-started.md
@@ -202,15 +202,17 @@ Global options:
 ## Running Benchmarks
 
 ```bash
-# Run benchmark on corpus
-./mosqueeze-bench --corpus corpus/ --output results/
+# Dry run configuration
+./mosqueeze-bench --directory ./corpus --iterations 3 --warmup 1 --dry-run
 
-# With specific algorithms
-./mosqueeze-bench --corpus corpus/ --algorithms zstd,lzma
+# Run benchmark on directory with selected engines
+./mosqueeze-bench --directory ./corpus --algorithms zstd,lzma,brotli,zpaq --summary
 
-# Export formats
-./mosqueeze-bench --corpus corpus/ --json --csv
+# Export Markdown report
+./mosqueeze-bench --directory ./corpus --export ./benchmarks/results/report.md --format markdown
 ```
+
+For full CLI reference and comparison workflow, see [[benchmark-tool]].
 
 ---
 

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -79,6 +79,7 @@ Dati reali dalle esecuzioni del benchmark harness.
 Documentazione operativa.
 
 - [[guides/getting-started]] - Build, test, contribuire
+- [[guides/benchmark-tool]] - Enhanced `mosqueeze-bench` usage and options
 - [[guides/adding-new-engine]] - Step-by-step per nuovo algoritmo
 - [[guides/cold-storage-patterns]] - Best practices archiviazione
 - [[guides/analyze-command]] - Come usare `mosqueeze analyze`

--- a/docs/wiki/log.md
+++ b/docs/wiki/log.md
@@ -50,3 +50,13 @@ Initial wiki population for Issue #16 â€” focus on algorithmic decision-mak
 ### Feature Docs: Video Support (Issue #21)
 - `algorithms/video-compression.md` - AVI/MKV strategy for cold storage with ZPAQ level 5
 - Updated `index.md` links to include video compression guidance
+
+### Feature Docs: Enhanced Benchmark Tool (Issue #23)
+- Added `guides/benchmark-tool.md` with full enhanced `mosqueeze-bench` CLI reference
+- Updated `benchmarks/methodology.md` to match current implementation:
+  - config-driven execution (`runWithConfig`)
+  - iterations + warmup
+  - timeout, decode/memory toggles
+  - stats aggregation and export behavior
+- Updated `guides/getting-started.md` benchmark examples for new options
+- Updated `index.md` to link the new benchmark guide

--- a/src/libmosqueeze/include/mosqueeze/bench/BenchmarkConfig.hpp
+++ b/src/libmosqueeze/include/mosqueeze/bench/BenchmarkConfig.hpp
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <chrono>
+#include <filesystem>
+#include <functional>
+#include <string>
+#include <vector>
+
+namespace mosqueeze::bench {
+
+struct ProgressInfo {
+    std::filesystem::path currentFile;
+    std::string currentAlgorithm;
+    int currentLevel = 0;
+    int currentIteration = 0;
+    int totalIterations = 0;
+    int totalFiles = 0;
+    int completedFiles = 0;
+    double progress = 0.0;
+};
+
+struct BenchmarkStats {
+    double meanRatio = 0.0;
+    double stdDevRatio = 0.0;
+    double meanEncodeTime = 0.0;
+    double stdDevEncodeTime = 0.0;
+    double meanDecodeTime = 0.0;
+    double stdDevDecodeTime = 0.0;
+    double meanPeakMemory = 0.0;
+    int iterations = 0;
+};
+
+struct BenchmarkConfig {
+    std::vector<std::filesystem::path> files;
+    bool useStdin = false;
+    std::filesystem::path corpusPath{"benchmarks/corpus"};
+
+    std::vector<std::string> algorithms;
+    std::vector<int> levels;
+    bool allEngines = false;
+    bool defaultOnly = false;
+
+    int iterations = 1;
+    int warmupIterations = 0;
+    bool trackMemory = true;
+    bool runDecode = true;
+    std::chrono::seconds maxTimePerFile{3600};
+
+    std::function<void(const ProgressInfo&)> onProgress;
+    std::function<bool()> shouldCancel;
+
+    bool hasProgressCallback() const { return static_cast<bool>(onProgress); }
+    bool hasCancellation() const { return static_cast<bool>(shouldCancel); }
+};
+
+} // namespace mosqueeze::bench

--- a/src/mosqueeze-bench/CMakeLists.txt
+++ b/src/mosqueeze-bench/CMakeLists.txt
@@ -1,7 +1,8 @@
-﻿find_package(CLI11 CONFIG REQUIRED)
+find_package(CLI11 CONFIG REQUIRED)
 find_package(fmt CONFIG REQUIRED)
 find_package(spdlog CONFIG REQUIRED)
 find_package(unofficial-sqlite3 CONFIG REQUIRED)
+find_package(nlohmann_json CONFIG REQUIRED)
 
 if(NOT TARGET SQLite::SQLite3)
   add_library(SQLite::SQLite3 ALIAS unofficial::sqlite3::sqlite3)
@@ -11,6 +12,7 @@ add_executable(mosqueeze-bench
   src/main.cpp
   src/BenchmarkRunner.cpp
   src/CorpusManager.cpp
+  src/Formatters.cpp
   src/ResultsStore.cpp
 )
 
@@ -21,6 +23,7 @@ target_link_libraries(mosqueeze-bench
     CLI11::CLI11
     fmt::fmt
     spdlog::spdlog
+    nlohmann_json::nlohmann_json
 )
 
 target_include_directories(mosqueeze-bench

--- a/src/mosqueeze-bench/include/mosqueeze/bench/BenchmarkRunner.hpp
+++ b/src/mosqueeze-bench/include/mosqueeze/bench/BenchmarkRunner.hpp
@@ -1,11 +1,13 @@
-﻿#pragma once
+#pragma once
 
 #include <mosqueeze/ICompressionEngine.hpp>
+#include <mosqueeze/bench/BenchmarkConfig.hpp>
 #include <mosqueeze/bench/BenchmarkResult.hpp>
 
 #include <filesystem>
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 namespace mosqueeze::bench {
@@ -13,8 +15,11 @@ namespace mosqueeze::bench {
 class BenchmarkRunner {
 public:
     BenchmarkRunner();
+    ~BenchmarkRunner();
 
     void registerEngine(std::unique_ptr<ICompressionEngine> engine);
+    std::vector<std::string> availableAlgorithms() const;
+    std::vector<int> availableLevels(const std::string& algorithm) const;
 
     std::vector<BenchmarkResult> run(
         const std::vector<std::filesystem::path>& files,
@@ -24,9 +29,20 @@ public:
     std::vector<BenchmarkResult> runGrid(
         const std::vector<std::filesystem::path>& files);
 
+    std::vector<BenchmarkResult> runWithConfig(const BenchmarkConfig& config);
+
+    std::unordered_map<std::string, BenchmarkStats> computeStats(
+        const std::vector<BenchmarkResult>& results) const;
+
 private:
     std::vector<std::unique_ptr<ICompressionEngine>> engines_;
     ICompressionEngine* findEngine(const std::string& name) const;
+    BenchmarkResult runIteration(
+        ICompressionEngine* engine,
+        const std::filesystem::path& file,
+        int level,
+        const BenchmarkConfig& config,
+        FileType fileType) const;
 };
 
 } // namespace mosqueeze::bench

--- a/src/mosqueeze-bench/include/mosqueeze/bench/Formatters.hpp
+++ b/src/mosqueeze-bench/include/mosqueeze/bench/Formatters.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <mosqueeze/bench/BenchmarkConfig.hpp>
+#include <mosqueeze/bench/BenchmarkResult.hpp>
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace mosqueeze::bench::Formatters {
+
+std::string formatVerbose(
+    const BenchmarkResult& result,
+    const BenchmarkStats* stats = nullptr);
+
+std::string formatSummaryTable(
+    const std::vector<BenchmarkResult>& results,
+    const std::unordered_map<std::string, BenchmarkStats>* stats = nullptr);
+
+std::string exportMarkdown(
+    const std::vector<BenchmarkResult>& results,
+    const std::unordered_map<std::string, BenchmarkStats>* stats = nullptr);
+
+std::string exportHtml(
+    const std::vector<BenchmarkResult>& results,
+    const std::unordered_map<std::string, BenchmarkStats>* stats = nullptr);
+
+} // namespace mosqueeze::bench::Formatters

--- a/src/mosqueeze-bench/src/BenchmarkRunner.cpp
+++ b/src/mosqueeze-bench/src/BenchmarkRunner.cpp
@@ -1,17 +1,35 @@
-﻿#include <mosqueeze/bench/BenchmarkRunner.hpp>
+#include <mosqueeze/bench/BenchmarkRunner.hpp>
 
 #include <mosqueeze/FileTypeDetector.hpp>
 
 #include <algorithm>
 #include <chrono>
+#include <cmath>
 #include <fstream>
 #include <sstream>
 #include <stdexcept>
+#include <unordered_map>
 #include <unordered_set>
 
 namespace mosqueeze::bench {
+namespace {
+
+double variance(const std::vector<double>& values, double mean) {
+    if (values.empty()) {
+        return 0.0;
+    }
+    double sum = 0.0;
+    for (double value : values) {
+        const double delta = value - mean;
+        sum += delta * delta;
+    }
+    return sum / static_cast<double>(values.size());
+}
+
+} // namespace
 
 BenchmarkRunner::BenchmarkRunner() = default;
+BenchmarkRunner::~BenchmarkRunner() = default;
 
 void BenchmarkRunner::registerEngine(std::unique_ptr<ICompressionEngine> engine) {
     if (!engine) {
@@ -20,28 +38,127 @@ void BenchmarkRunner::registerEngine(std::unique_ptr<ICompressionEngine> engine)
     engines_.push_back(std::move(engine));
 }
 
+std::vector<std::string> BenchmarkRunner::availableAlgorithms() const {
+    std::vector<std::string> names;
+    names.reserve(engines_.size());
+    for (const auto& engine : engines_) {
+        names.push_back(engine->name());
+    }
+    std::sort(names.begin(), names.end());
+    return names;
+}
+
+std::vector<int> BenchmarkRunner::availableLevels(const std::string& algorithm) const {
+    auto* engine = findEngine(algorithm);
+    if (!engine) {
+        return {};
+    }
+    auto levels = engine->supportedLevels();
+    std::sort(levels.begin(), levels.end());
+    return levels;
+}
+
 ICompressionEngine* BenchmarkRunner::findEngine(const std::string& name) const {
     auto it = std::find_if(engines_.begin(), engines_.end(), [&](const auto& engine) {
         return engine->name() == name;
     });
-
     return it == engines_.end() ? nullptr : it->get();
+}
+
+BenchmarkResult BenchmarkRunner::runIteration(
+    ICompressionEngine* engine,
+    const std::filesystem::path& file,
+    int level,
+    const BenchmarkConfig& config,
+    FileType fileType) const {
+    std::ifstream in(file, std::ios::binary);
+    if (!in) {
+        throw std::runtime_error("Failed to open file for benchmark: " + file.string());
+    }
+
+    std::ostringstream compressed;
+    CompressionOptions opts{};
+    opts.level = level;
+    opts.extreme = level >= engine->maxLevel();
+
+    const auto encodeStart = std::chrono::steady_clock::now();
+    CompressionResult encodeResult = engine->compress(in, compressed, opts);
+    const auto encodeEnd = std::chrono::steady_clock::now();
+    const auto encodeDuration = std::chrono::duration_cast<std::chrono::milliseconds>(encodeEnd - encodeStart);
+
+    if (encodeDuration > config.maxTimePerFile) {
+        throw std::runtime_error(
+            "Compression exceeded max time for file: " + file.string() + " (" + engine->name() + ")");
+    }
+
+    std::chrono::milliseconds decodeDuration{0};
+    if (config.runDecode) {
+        std::istringstream compressedInput(compressed.str());
+        std::ostringstream decompressed;
+
+        const auto decodeStart = std::chrono::steady_clock::now();
+        engine->decompress(compressedInput, decompressed);
+        const auto decodeEnd = std::chrono::steady_clock::now();
+        decodeDuration = std::chrono::duration_cast<std::chrono::milliseconds>(decodeEnd - decodeStart);
+
+        if (decodeDuration > config.maxTimePerFile) {
+            throw std::runtime_error(
+                "Decompression exceeded max time for file: " + file.string() + " (" + engine->name() + ")");
+        }
+    }
+
+    BenchmarkResult row{};
+    row.algorithm = engine->name();
+    row.level = level;
+    row.file = file;
+    row.fileType = fileType;
+    row.originalBytes = encodeResult.originalBytes;
+    row.compressedBytes = encodeResult.compressedBytes;
+    row.encodeTime = encodeDuration;
+    row.decodeTime = decodeDuration;
+    row.peakMemoryBytes = config.trackMemory ? encodeResult.peakMemoryBytes : 0;
+    return row;
 }
 
 std::vector<BenchmarkResult> BenchmarkRunner::run(
     const std::vector<std::filesystem::path>& files,
     const std::vector<std::string>& algorithms,
     const std::vector<int>& levels) {
+    BenchmarkConfig config;
+    config.files = files;
+    config.algorithms = algorithms;
+    config.levels = levels;
+    return runWithConfig(config);
+}
+
+std::vector<BenchmarkResult> BenchmarkRunner::runGrid(
+    const std::vector<std::filesystem::path>& files) {
+    BenchmarkConfig config;
+    config.files = files;
+    config.allEngines = true;
+    return runWithConfig(config);
+}
+
+std::vector<BenchmarkResult> BenchmarkRunner::runWithConfig(const BenchmarkConfig& config) {
     if (engines_.empty()) {
         throw std::runtime_error("No engines registered in BenchmarkRunner");
     }
 
-    std::unordered_set<std::string> selectedAlgorithms(algorithms.begin(), algorithms.end());
+    if (config.files.empty()) {
+        return {};
+    }
 
     std::vector<ICompressionEngine*> selectedEngines;
-    for (const auto& engine : engines_) {
-        if (selectedAlgorithms.empty() || selectedAlgorithms.count(engine->name()) > 0) {
+    if (config.allEngines || config.algorithms.empty()) {
+        for (const auto& engine : engines_) {
             selectedEngines.push_back(engine.get());
+        }
+    } else {
+        std::unordered_set<std::string> selectedAlgorithms(config.algorithms.begin(), config.algorithms.end());
+        for (const auto& engine : engines_) {
+            if (selectedAlgorithms.count(engine->name()) > 0) {
+                selectedEngines.push_back(engine.get());
+            }
         }
     }
 
@@ -49,72 +166,154 @@ std::vector<BenchmarkResult> BenchmarkRunner::run(
         throw std::runtime_error("No matching engines found for requested algorithms");
     }
 
+    std::unordered_map<std::string, std::vector<int>> levelsByAlgorithm;
+    for (auto* engine : selectedEngines) {
+        std::vector<int> levelSet;
+        if (config.defaultOnly) {
+            levelSet = {engine->defaultLevel()};
+        } else if (config.levels.empty()) {
+            levelSet = engine->supportedLevels();
+        } else {
+            const auto supported = engine->supportedLevels();
+            for (int level : config.levels) {
+                if (std::find(supported.begin(), supported.end(), level) != supported.end()) {
+                    levelSet.push_back(level);
+                }
+            }
+            if (levelSet.empty()) {
+                levelSet.push_back(engine->defaultLevel());
+            }
+        }
+        std::sort(levelSet.begin(), levelSet.end());
+        levelSet.erase(std::unique(levelSet.begin(), levelSet.end()), levelSet.end());
+        levelsByAlgorithm[engine->name()] = std::move(levelSet);
+    }
+
+    const int iterations = std::max(1, config.iterations);
+    const int warmups = std::max(0, config.warmupIterations);
+    int unitsPerFile = 0;
+    for (auto* engine : selectedEngines) {
+        unitsPerFile += static_cast<int>(levelsByAlgorithm[engine->name()].size()) * (iterations + warmups);
+    }
+    const int totalWork = std::max(1, unitsPerFile * static_cast<int>(config.files.size()));
+    int completedWork = 0;
+
     FileTypeDetector detector;
     std::vector<BenchmarkResult> results;
 
-    for (const auto& file : files) {
+    auto lastProgressEmit = std::chrono::steady_clock::time_point{};
+    auto emitProgress = [&](const std::filesystem::path& file,
+                            const std::string& algorithm,
+                            int level,
+                            int currentIteration,
+                            bool force) {
+        if (!config.hasProgressCallback()) {
+            return;
+        }
+
+        const auto now = std::chrono::steady_clock::now();
+        if (!force && lastProgressEmit != std::chrono::steady_clock::time_point{} &&
+            (now - lastProgressEmit) < std::chrono::milliseconds(100)) {
+            return;
+        }
+
+        ProgressInfo info{};
+        info.currentFile = file;
+        info.currentAlgorithm = algorithm;
+        info.currentLevel = level;
+        info.currentIteration = currentIteration;
+        info.totalIterations = iterations + warmups;
+        info.totalFiles = static_cast<int>(config.files.size());
+        info.completedFiles = unitsPerFile > 0 ? completedWork / unitsPerFile : 0;
+        info.progress = static_cast<double>(completedWork) / static_cast<double>(totalWork);
+        config.onProgress(info);
+        lastProgressEmit = now;
+    };
+
+    for (const auto& file : config.files) {
+        if (config.hasCancellation() && config.shouldCancel()) {
+            break;
+        }
+
         const auto classification = detector.detect(file);
-
-        for (ICompressionEngine* engine : selectedEngines) {
-            std::vector<int> levelSet;
-            if (levels.empty()) {
-                levelSet = engine->supportedLevels();
-            } else {
-                const auto supported = engine->supportedLevels();
-                for (int level : levels) {
-                    if (std::find(supported.begin(), supported.end(), level) != supported.end()) {
-                        levelSet.push_back(level);
-                    }
-                }
-                if (levelSet.empty()) {
-                    levelSet.push_back(engine->defaultLevel());
-                }
-            }
-
+        for (auto* engine : selectedEngines) {
+            const auto& levelSet = levelsByAlgorithm.at(engine->name());
             for (int level : levelSet) {
-                std::ifstream in(file, std::ios::binary);
-                if (!in) {
-                    throw std::runtime_error("Failed to open file for benchmark: " + file.string());
+                for (int i = 0; i < warmups; ++i) {
+                    (void)runIteration(engine, file, level, config, classification.type);
+                    ++completedWork;
+                    emitProgress(file, engine->name(), level, i + 1, false);
                 }
 
-                std::ostringstream compressed;
-                CompressionOptions opts{};
-                opts.level = level;
-                opts.extreme = level >= engine->maxLevel();
-
-                const auto encodeStart = std::chrono::steady_clock::now();
-                CompressionResult encodeResult = engine->compress(in, compressed, opts);
-                const auto encodeEnd = std::chrono::steady_clock::now();
-
-                std::istringstream compressedInput(compressed.str());
-                std::ostringstream decompressed;
-
-                const auto decodeStart = std::chrono::steady_clock::now();
-                engine->decompress(compressedInput, decompressed);
-                const auto decodeEnd = std::chrono::steady_clock::now();
-
-                BenchmarkResult row{};
-                row.algorithm = engine->name();
-                row.level = level;
-                row.file = file;
-                row.fileType = classification.type;
-                row.originalBytes = encodeResult.originalBytes;
-                row.compressedBytes = encodeResult.compressedBytes;
-                row.encodeTime = std::chrono::duration_cast<std::chrono::milliseconds>(encodeEnd - encodeStart);
-                row.decodeTime = std::chrono::duration_cast<std::chrono::milliseconds>(decodeEnd - decodeStart);
-                row.peakMemoryBytes = encodeResult.peakMemoryBytes;
-
-                results.push_back(std::move(row));
+                for (int i = 0; i < iterations; ++i) {
+                    results.push_back(runIteration(engine, file, level, config, classification.type));
+                    ++completedWork;
+                    emitProgress(file, engine->name(), level, warmups + i + 1, false);
+                }
             }
         }
     }
 
+    emitProgress({}, "", 0, 0, true);
     return results;
 }
 
-std::vector<BenchmarkResult> BenchmarkRunner::runGrid(
-    const std::vector<std::filesystem::path>& files) {
-    return run(files, {}, {});
+std::unordered_map<std::string, BenchmarkStats> BenchmarkRunner::computeStats(
+    const std::vector<BenchmarkResult>& results) const {
+    std::unordered_map<std::string, std::vector<const BenchmarkResult*>> grouped;
+    for (const auto& result : results) {
+        const std::string key = result.algorithm + "/" + std::to_string(result.level);
+        grouped[key].push_back(&result);
+    }
+
+    std::unordered_map<std::string, BenchmarkStats> stats;
+    for (const auto& [key, values] : grouped) {
+        if (values.empty()) {
+            continue;
+        }
+
+        std::vector<double> ratios;
+        std::vector<double> encode;
+        std::vector<double> decode;
+        std::vector<double> memory;
+        ratios.reserve(values.size());
+        encode.reserve(values.size());
+        decode.reserve(values.size());
+        memory.reserve(values.size());
+
+        double ratioSum = 0.0;
+        double encodeSum = 0.0;
+        double decodeSum = 0.0;
+        double memorySum = 0.0;
+        for (const BenchmarkResult* value : values) {
+            const double ratio = value->ratio();
+            const double encodeMs = static_cast<double>(value->encodeTime.count());
+            const double decodeMs = static_cast<double>(value->decodeTime.count());
+            const double memoryBytes = static_cast<double>(value->peakMemoryBytes);
+
+            ratios.push_back(ratio);
+            encode.push_back(encodeMs);
+            decode.push_back(decodeMs);
+            memory.push_back(memoryBytes);
+
+            ratioSum += ratio;
+            encodeSum += encodeMs;
+            decodeSum += decodeMs;
+            memorySum += memoryBytes;
+        }
+
+        BenchmarkStats row{};
+        row.iterations = static_cast<int>(values.size());
+        row.meanRatio = ratioSum / static_cast<double>(values.size());
+        row.meanEncodeTime = encodeSum / static_cast<double>(values.size());
+        row.meanDecodeTime = decodeSum / static_cast<double>(values.size());
+        row.meanPeakMemory = memorySum / static_cast<double>(values.size());
+        row.stdDevRatio = std::sqrt(variance(ratios, row.meanRatio));
+        row.stdDevEncodeTime = std::sqrt(variance(encode, row.meanEncodeTime));
+        row.stdDevDecodeTime = std::sqrt(variance(decode, row.meanDecodeTime));
+        stats[key] = row;
+    }
+    return stats;
 }
 
 } // namespace mosqueeze::bench

--- a/src/mosqueeze-bench/src/Formatters.cpp
+++ b/src/mosqueeze-bench/src/Formatters.cpp
@@ -1,0 +1,229 @@
+#include <mosqueeze/bench/Formatters.hpp>
+
+#include <algorithm>
+#include <filesystem>
+#include <iomanip>
+#include <map>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace mosqueeze::bench::Formatters {
+namespace {
+
+std::string formatDuration(std::chrono::milliseconds duration) {
+    std::ostringstream out;
+    out << duration.count() << "ms";
+    return out.str();
+}
+
+std::string formatBytes(size_t bytes) {
+    static const char* suffixes[] = {"B", "KB", "MB", "GB", "TB"};
+    double value = static_cast<double>(bytes);
+    size_t suffix = 0;
+    while (value >= 1024.0 && suffix < (sizeof(suffixes) / sizeof(suffixes[0])) - 1) {
+        value /= 1024.0;
+        ++suffix;
+    }
+
+    std::ostringstream out;
+    out << std::fixed << std::setprecision(suffix == 0 ? 0 : 2) << value << suffixes[suffix];
+    return out.str();
+}
+
+std::string formatRatio(double ratio) {
+    std::ostringstream out;
+    out << std::fixed << std::setprecision(3) << ratio << "x";
+    return out.str();
+}
+
+std::string statsKey(const BenchmarkResult& result) {
+    return result.algorithm + "/" + std::to_string(result.level);
+}
+
+} // namespace
+
+std::string formatVerbose(const BenchmarkResult& result, const BenchmarkStats* stats) {
+    std::ostringstream out;
+    out << result.file.filename().string() << " | "
+        << result.algorithm << "/" << result.level << " | ratio "
+        << std::fixed << std::setprecision(3) << result.ratio() << "x | encode "
+        << formatDuration(result.encodeTime) << " | decode " << formatDuration(result.decodeTime)
+        << " | memory " << formatBytes(result.peakMemoryBytes);
+
+    if (stats != nullptr) {
+        out << " | mean ratio " << std::fixed << std::setprecision(3) << stats->meanRatio
+            << " +/- " << stats->stdDevRatio;
+    }
+    return out.str();
+}
+
+std::string formatSummaryTable(
+    const std::vector<BenchmarkResult>& results,
+    const std::unordered_map<std::string, BenchmarkStats>* stats) {
+    std::vector<BenchmarkResult> sorted = results;
+    std::sort(sorted.begin(), sorted.end(), [](const auto& lhs, const auto& rhs) {
+        if (lhs.algorithm != rhs.algorithm) {
+            return lhs.algorithm < rhs.algorithm;
+        }
+        if (lhs.level != rhs.level) {
+            return lhs.level < rhs.level;
+        }
+        return lhs.ratio() > rhs.ratio();
+    });
+
+    std::ostringstream out;
+    out << "Algorithm      Level  Ratio    Encode   Decode   Memory\n";
+    out << "--------------------------------------------------------\n";
+    for (const auto& result : sorted) {
+        out << std::left << std::setw(14) << result.algorithm
+            << std::setw(7) << result.level
+            << std::setw(9) << formatRatio(result.ratio())
+            << std::setw(9) << formatDuration(result.encodeTime)
+            << std::setw(9) << formatDuration(result.decodeTime)
+            << formatBytes(result.peakMemoryBytes);
+
+        if (stats != nullptr) {
+            auto it = stats->find(statsKey(result));
+            if (it != stats->end()) {
+                out << "  (n=" << it->second.iterations << ")";
+            }
+        }
+
+        out << '\n';
+    }
+    return out.str();
+}
+
+std::string exportMarkdown(
+    const std::vector<BenchmarkResult>& results,
+    const std::unordered_map<std::string, BenchmarkStats>* stats) {
+    std::map<std::filesystem::path, std::vector<BenchmarkResult>> byFile;
+    for (const auto& result : results) {
+        byFile[result.file].push_back(result);
+    }
+
+    std::ostringstream out;
+    out << "# Benchmark Results\n\n";
+    for (const auto& [file, rows] : byFile) {
+        out << "## " << file.filename().string() << "\n\n";
+        out << "| Algorithm | Level | Ratio | Encode | Decode | Memory | Stats |\n";
+        out << "|---|---:|---:|---:|---:|---:|---|\n";
+
+        std::vector<BenchmarkResult> sorted = rows;
+        std::sort(sorted.begin(), sorted.end(), [](const auto& lhs, const auto& rhs) {
+            return lhs.ratio() > rhs.ratio();
+        });
+
+        for (const auto& result : sorted) {
+            out << "| " << result.algorithm
+                << " | " << result.level
+                << " | " << std::fixed << std::setprecision(3) << result.ratio() << "x"
+                << " | " << result.encodeTime.count() << "ms"
+                << " | " << result.decodeTime.count() << "ms"
+                << " | " << formatBytes(result.peakMemoryBytes)
+                << " | ";
+            if (stats != nullptr) {
+                auto it = stats->find(statsKey(result));
+                if (it != stats->end()) {
+                    out << "n=" << it->second.iterations << ", mean=" << std::fixed << std::setprecision(3)
+                        << it->second.meanRatio << "x";
+                }
+            }
+            out << " |\n";
+        }
+        out << '\n';
+    }
+    return out.str();
+}
+
+std::string exportHtml(
+    const std::vector<BenchmarkResult>& results,
+    const std::unordered_map<std::string, BenchmarkStats>* stats) {
+    std::ostringstream rows;
+    std::vector<BenchmarkResult> sorted = results;
+    std::sort(sorted.begin(), sorted.end(), [](const auto& lhs, const auto& rhs) {
+        if (lhs.file != rhs.file) {
+            return lhs.file < rhs.file;
+        }
+        if (lhs.algorithm != rhs.algorithm) {
+            return lhs.algorithm < rhs.algorithm;
+        }
+        return lhs.level < rhs.level;
+    });
+
+    for (const auto& result : sorted) {
+        rows << "<tr>"
+             << "<td>" << result.file.filename().string() << "</td>"
+             << "<td>" << result.algorithm << "</td>"
+             << "<td>" << result.level << "</td>"
+             << "<td>" << std::fixed << std::setprecision(3) << result.ratio() << "x</td>"
+             << "<td>" << result.encodeTime.count() << " ms</td>"
+             << "<td>" << result.decodeTime.count() << " ms</td>"
+             << "<td>" << formatBytes(result.peakMemoryBytes) << "</td>";
+
+        std::string statsCell;
+        if (stats != nullptr) {
+            auto it = stats->find(statsKey(result));
+            if (it != stats->end()) {
+                std::ostringstream cell;
+                cell << "n=" << it->second.iterations << ", mean ratio "
+                     << std::fixed << std::setprecision(3) << it->second.meanRatio << "x";
+                statsCell = cell.str();
+            }
+        }
+        rows << "<td>" << statsCell << "</td>";
+        rows << "</tr>\n";
+    }
+
+    std::ostringstream out;
+    out << "<!doctype html>\n"
+        << "<html lang=\"en\">\n"
+        << "<head>\n"
+        << "<meta charset=\"utf-8\">\n"
+        << "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n"
+        << "<title>MoSqueeze Benchmark Results</title>\n"
+        << "<script src=\"https://cdn.jsdelivr.net/npm/chart.js\"></script>\n"
+        << "<style>\n"
+        << "body{font-family:Segoe UI,Tahoma,sans-serif;margin:24px;background:#f6f8fb;color:#1b2430;}\n"
+        << "h1{margin-bottom:12px;}\n"
+        << "table{border-collapse:collapse;width:100%;background:white;}\n"
+        << "th,td{border:1px solid #d9e2ec;padding:8px;text-align:left;font-size:14px;}\n"
+        << "th{background:#334e68;color:white;}\n"
+        << "tr:nth-child(even){background:#f8fbff;}\n"
+        << ".card{background:white;padding:16px;border:1px solid #d9e2ec;margin-bottom:18px;}\n"
+        << "</style>\n"
+        << "</head>\n"
+        << "<body>\n"
+        << "<h1>MoSqueeze Benchmark Results</h1>\n"
+        << "<div class=\"card\"><canvas id=\"ratioChart\"></canvas></div>\n"
+        << "<table>\n"
+        << "<thead><tr><th>File</th><th>Algorithm</th><th>Level</th><th>Ratio</th><th>Encode</th><th>Decode</th><th>Memory</th><th>Stats</th></tr></thead>\n"
+        << "<tbody>\n"
+        << rows.str()
+        << "</tbody></table>\n"
+        << "<script>\n"
+        << "const labels=[";
+
+    for (size_t i = 0; i < sorted.size(); ++i) {
+        if (i > 0) {
+            out << ",";
+        }
+        out << "\"" << sorted[i].algorithm << "/" << sorted[i].level << "\"";
+    }
+    out << "];\nconst data=[";
+    for (size_t i = 0; i < sorted.size(); ++i) {
+        if (i > 0) {
+            out << ",";
+        }
+        out << std::fixed << std::setprecision(3) << sorted[i].ratio();
+    }
+    out << "];\n"
+        << "new Chart(document.getElementById('ratioChart'),{type:'bar',data:{labels,datasets:[{label:'Compression ratio',data,backgroundColor:'#627d98'}]}});\n"
+        << "</script>\n"
+        << "</body>\n"
+        << "</html>\n";
+    return out.str();
+}
+
+} // namespace mosqueeze::bench::Formatters

--- a/src/mosqueeze-bench/src/main.cpp
+++ b/src/mosqueeze-bench/src/main.cpp
@@ -1,81 +1,480 @@
-﻿#include <mosqueeze/bench/BenchmarkRunner.hpp>
+#include <mosqueeze/bench/BenchmarkRunner.hpp>
 #include <mosqueeze/bench/CorpusManager.hpp>
+#include <mosqueeze/bench/Formatters.hpp>
 #include <mosqueeze/bench/ResultsStore.hpp>
 #include <mosqueeze/engines/BrotliEngine.hpp>
 #include <mosqueeze/engines/LzmaEngine.hpp>
+#include <mosqueeze/engines/ZpaqEngine.hpp>
 #include <mosqueeze/engines/ZstdEngine.hpp>
 
 #include <CLI/CLI.hpp>
+#include <nlohmann/json.hpp>
 
 #include <algorithm>
+#include <chrono>
+#include <cmath>
 #include <filesystem>
+#include <fstream>
+#include <iomanip>
 #include <iostream>
 #include <memory>
+#include <regex>
+#include <sstream>
+#include <stdexcept>
 #include <string>
+#include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
-int main(int argc, char* argv[]) {
-    CLI::App app{"MoSqueeze Benchmark Harness", "mosqueeze-bench"};
+namespace {
 
-    std::string corpusPath = "benchmarks/corpus";
-    std::string outputPath = "benchmarks/results";
-    bool json = true;
-    bool csv = false;
+std::vector<std::string> splitCsv(const std::string& csv) {
+    std::vector<std::string> values;
+    std::stringstream ss(csv);
+    std::string token;
+    while (std::getline(ss, token, ',')) {
+        if (!token.empty()) {
+            values.push_back(token);
+        }
+    }
+    return values;
+}
 
-    app.add_option("-c,--corpus", corpusPath, "Path to corpus directory");
-    app.add_option("-o,--output", outputPath, "Output directory for results");
-    app.add_flag("--json", json, "Export results as JSON");
-    app.add_flag("--csv", csv, "Export results as CSV");
+std::vector<int> splitCsvIntegers(const std::string& csv) {
+    std::vector<int> values;
+    for (const auto& token : splitCsv(csv)) {
+        values.push_back(std::stoi(token));
+    }
+    return values;
+}
 
-    CLI11_PARSE(app, argc, argv);
+std::string wildcardToRegex(const std::string& pattern) {
+    std::string regex = "^";
+    for (const char c : pattern) {
+        switch (c) {
+            case '*':
+                regex += ".*";
+                break;
+            case '?':
+                regex += ".";
+                break;
+            case '.':
+            case '+':
+            case '(':
+            case ')':
+            case '[':
+            case ']':
+            case '{':
+            case '}':
+            case '^':
+            case '$':
+            case '|':
+            case '\\':
+                regex += '\\';
+                regex += c;
+                break;
+            default:
+                regex += c;
+                break;
+        }
+    }
+    regex += "$";
+    return regex;
+}
 
-    mosqueeze::bench::BenchmarkRunner runner;
+std::vector<std::filesystem::path> globFiles(const std::string& pattern) {
+    std::vector<std::filesystem::path> files;
+    const std::regex matcher(wildcardToRegex(pattern), std::regex::icase);
+    for (const auto& entry : std::filesystem::recursive_directory_iterator(std::filesystem::current_path())) {
+        if (!entry.is_regular_file()) {
+            continue;
+        }
+        if (std::regex_match(entry.path().filename().string(), matcher)) {
+            files.push_back(entry.path());
+        }
+    }
+    return files;
+}
+
+void appendDirectoryFiles(const std::filesystem::path& directory, std::vector<std::filesystem::path>& files) {
+    for (const auto& entry : std::filesystem::recursive_directory_iterator(directory)) {
+        if (entry.is_regular_file()) {
+            files.push_back(entry.path());
+        }
+    }
+}
+
+void appendStdinFiles(std::vector<std::filesystem::path>& files) {
+    std::string line;
+    while (std::getline(std::cin, line)) {
+        if (!line.empty()) {
+            files.emplace_back(line);
+        }
+    }
+}
+
+void dedupeFiles(std::vector<std::filesystem::path>& files) {
+    std::vector<std::filesystem::path> normalized;
+    normalized.reserve(files.size());
+    for (const auto& file : files) {
+        std::error_code ec;
+        const auto canonical = std::filesystem::weakly_canonical(file, ec);
+        normalized.push_back(ec ? std::filesystem::absolute(file) : canonical);
+    }
+    std::sort(normalized.begin(), normalized.end());
+    normalized.erase(std::unique(normalized.begin(), normalized.end()), normalized.end());
+    files = std::move(normalized);
+}
+
+struct ComparisonRow {
+    std::string key;
+    double meanRatio = 0.0;
+    double meanEncodeMs = 0.0;
+    double meanDecodeMs = 0.0;
+};
+
+std::unordered_map<std::string, ComparisonRow> summarize(const std::vector<mosqueeze::bench::BenchmarkResult>& rows) {
+    struct Agg {
+        double ratio = 0.0;
+        double encode = 0.0;
+        double decode = 0.0;
+        int count = 0;
+    };
+    std::unordered_map<std::string, Agg> agg;
+    for (const auto& row : rows) {
+        const std::string key = row.file.string() + "|" + row.algorithm + "|" + std::to_string(row.level);
+        auto& target = agg[key];
+        target.ratio += row.ratio();
+        target.encode += static_cast<double>(row.encodeTime.count());
+        target.decode += static_cast<double>(row.decodeTime.count());
+        ++target.count;
+    }
+
+    std::unordered_map<std::string, ComparisonRow> out;
+    for (const auto& [key, value] : agg) {
+        ComparisonRow row{};
+        row.key = key;
+        row.meanRatio = value.ratio / value.count;
+        row.meanEncodeMs = value.encode / value.count;
+        row.meanDecodeMs = value.decode / value.count;
+        out[key] = row;
+    }
+    return out;
+}
+
+std::vector<mosqueeze::bench::BenchmarkResult> loadComparisonRows(const std::filesystem::path& file) {
+    std::vector<mosqueeze::bench::BenchmarkResult> rows;
+    if (!std::filesystem::exists(file)) {
+        throw std::runtime_error("Comparison file does not exist: " + file.string());
+    }
+
+    const auto ext = file.extension().string();
+    if (ext == ".json") {
+        std::ifstream in(file, std::ios::binary);
+        nlohmann::json payload;
+        in >> payload;
+        if (!payload.is_array()) {
+            throw std::runtime_error("Comparison JSON must be an array");
+        }
+        for (const auto& item : payload) {
+            mosqueeze::bench::BenchmarkResult row{};
+            row.algorithm = item.value("algorithm", "");
+            row.level = item.value("level", 0);
+            row.file = item.value("file", "");
+            row.originalBytes = item.value("originalBytes", static_cast<size_t>(0));
+            row.compressedBytes = item.value("compressedBytes", static_cast<size_t>(0));
+            row.encodeTime = std::chrono::milliseconds(item.value("encodeMs", 0));
+            row.decodeTime = std::chrono::milliseconds(item.value("decodeMs", 0));
+            row.peakMemoryBytes = item.value("peakMemoryBytes", static_cast<size_t>(0));
+            rows.push_back(std::move(row));
+        }
+    } else {
+        std::ifstream in(file, std::ios::binary);
+        std::string line;
+        if (!std::getline(in, line)) {
+            return rows;
+        }
+        while (std::getline(in, line)) {
+            if (line.empty()) {
+                continue;
+            }
+            std::stringstream ss(line);
+            std::vector<std::string> cols;
+            std::string col;
+            while (std::getline(ss, col, ',')) {
+                cols.push_back(col);
+            }
+            if (cols.size() < 9) {
+                continue;
+            }
+            mosqueeze::bench::BenchmarkResult row{};
+            row.algorithm = cols[0];
+            row.level = std::stoi(cols[1]);
+            if (!cols[2].empty() && cols[2].front() == '"' && cols[2].back() == '"') {
+                row.file = cols[2].substr(1, cols[2].size() - 2);
+            } else {
+                row.file = cols[2];
+            }
+            row.originalBytes = static_cast<size_t>(std::stoll(cols[4]));
+            row.compressedBytes = static_cast<size_t>(std::stoll(cols[5]));
+            row.encodeTime = std::chrono::milliseconds(std::stoll(cols[6]));
+            row.decodeTime = std::chrono::milliseconds(std::stoll(cols[7]));
+            row.peakMemoryBytes = static_cast<size_t>(std::stoll(cols[8]));
+            rows.push_back(std::move(row));
+        }
+    }
+    return rows;
+}
+
+void printComparison(
+    const std::vector<mosqueeze::bench::BenchmarkResult>& current,
+    const std::vector<mosqueeze::bench::BenchmarkResult>& previous,
+    bool diffOnly) {
+    const auto currentAgg = summarize(current);
+    const auto previousAgg = summarize(previous);
+    std::cout << "\n=== Comparison ===\n";
+    std::cout << "Key | Ratio Delta | Encode Delta(ms) | Decode Delta(ms)\n";
+    std::cout << "-------------------------------------------------------\n";
+    for (const auto& [key, curr] : currentAgg) {
+        auto it = previousAgg.find(key);
+        if (it == previousAgg.end()) {
+            if (!diffOnly) {
+                std::cout << key << " | new | new | new\n";
+            }
+            continue;
+        }
+        const double ratioDelta = curr.meanRatio - it->second.meanRatio;
+        const double encodeDelta = curr.meanEncodeMs - it->second.meanEncodeMs;
+        const double decodeDelta = curr.meanDecodeMs - it->second.meanDecodeMs;
+        if (diffOnly && std::abs(ratioDelta) < 1e-9 && std::abs(encodeDelta) < 1e-9 && std::abs(decodeDelta) < 1e-9) {
+            continue;
+        }
+        std::cout << key << " | "
+                  << std::fixed << std::setprecision(4) << ratioDelta << " | "
+                  << std::fixed << std::setprecision(2) << encodeDelta << " | "
+                  << std::fixed << std::setprecision(2) << decodeDelta << '\n';
+    }
+}
+
+void registerDefaultEngines(mosqueeze::bench::BenchmarkRunner& runner) {
     runner.registerEngine(std::make_unique<mosqueeze::ZstdEngine>());
     runner.registerEngine(std::make_unique<mosqueeze::LzmaEngine>());
     runner.registerEngine(std::make_unique<mosqueeze::BrotliEngine>());
+    runner.registerEngine(std::make_unique<mosqueeze::ZpaqEngine>());
+}
 
-    mosqueeze::bench::CorpusManager corpus(corpusPath);
-    corpus.downloadStandardCorpus();
+} // namespace
 
-    std::filesystem::create_directories(outputPath);
-    mosqueeze::bench::ResultsStore store((std::filesystem::path(outputPath) / "results.sqlite3"));
+int main(int argc, char* argv[]) {
+    CLI::App app{"MoSqueeze Benchmark Tool", "mosqueeze-bench"};
 
-    std::cout << "MoSqueeze Benchmark Harness v0.1.0\n";
-    std::cout << "Corpus: " << corpus.totalFiles() << " files ("
-              << corpus.totalSize() << " bytes)\n";
+    std::vector<std::filesystem::path> files;
+    std::filesystem::path directory;
+    std::string globPattern;
+    bool useStdin = false;
+    std::filesystem::path corpusPath{"benchmarks/corpus"};
 
-    auto files = corpus.listFiles();
-    std::vector<std::filesystem::path> paths;
-    paths.reserve(files.size());
-    for (const auto& file : files) {
-        paths.push_back(file.path);
+    std::string algorithmsOpt;
+    std::string levelsOpt;
+    bool allEngines = false;
+    bool defaultOnly = false;
+
+    int iterations = 1;
+    int warmup = 0;
+    bool trackMemory = true;
+    bool noMemory = false;
+    int maxTime = 3600;
+    bool runDecode = true;
+    bool noDecode = false;
+
+    std::filesystem::path outputDir{"benchmarks/results"};
+    std::filesystem::path exportFile;
+    std::string format = "json";
+    bool verbose = false;
+    bool quiet = false;
+    bool summary = false;
+    bool noColor = false;
+
+    std::filesystem::path compareFile;
+    bool diffOnly = false;
+
+    bool dryRun = false;
+    bool listEngines = false;
+    bool showVersion = false;
+
+    app.add_option("-f,--file", files, "Add single file to benchmark");
+    app.add_option("-d,--directory", directory, "Add all files from directory (recursive)");
+    app.add_option("-g,--glob", globPattern, "Add files matching glob pattern");
+    app.add_option("-c,--corpus", corpusPath, "Use standard corpus path");
+    app.add_flag("--stdin", useStdin, "Read file paths from stdin");
+
+    app.add_option("-a,--algorithms", algorithmsOpt, "Comma-separated algorithms");
+    app.add_option("-l,--levels", levelsOpt, "Comma-separated levels");
+    app.add_flag("--all-engines", allEngines, "Test all registered engines");
+    app.add_flag("--default-only", defaultOnly, "Use only default level for each engine");
+
+    app.add_option("-i,--iterations", iterations, "Number of iterations")->check(CLI::PositiveNumber);
+    app.add_option("-w,--warmup", warmup, "Warmup iterations")->check(CLI::NonNegativeNumber);
+    app.add_flag("--track-memory", trackMemory, "Track peak memory usage");
+    app.add_flag("--no-memory", noMemory, "Disable memory tracking");
+    app.add_option("--max-time", maxTime, "Max time per compression in seconds")->check(CLI::PositiveNumber);
+    app.add_flag("--decode", runDecode, "Include decompression benchmark");
+    app.add_flag("--no-decode", noDecode, "Skip decompression benchmark");
+
+    app.add_option("-o,--output", outputDir, "Output directory");
+    app.add_option("--export", exportFile, "Export results to file");
+    app.add_option("--format", format, "Export format: json,csv,markdown,html")
+        ->check(CLI::IsMember({"json", "csv", "markdown", "html"}));
+    app.add_flag("-v,--verbose", verbose, "Verbose console output with progress");
+    app.add_flag("-q,--quiet", quiet, "Quiet mode (errors only)");
+    app.add_flag("--summary", summary, "Print summary table only");
+    app.add_flag("--no-color", noColor, "Disable ANSI colors");
+
+    app.add_option("--compare", compareFile, "Compare with previous results (JSON/CSV)");
+    app.add_flag("--diff-only", diffOnly, "Show only files with different results");
+
+    app.add_flag("--dry-run", dryRun, "Show configuration without running");
+    app.add_flag("--list-engines", listEngines, "List available engines and levels");
+    app.add_flag("--version", showVersion, "Show version");
+
+    app.get_formatter()->column_width(34);
+    CLI11_PARSE(app, argc, argv);
+
+    (void)noColor;
+    trackMemory = trackMemory && !noMemory;
+    runDecode = runDecode && !noDecode;
+
+    mosqueeze::bench::BenchmarkRunner runner;
+    registerDefaultEngines(runner);
+
+    if (showVersion) {
+        std::cout << "mosqueeze-bench 0.2.0\n";
+        return 0;
     }
 
-    auto results = runner.runGrid(paths);
+    if (listEngines) {
+        std::cout << "Available engines:\n";
+        for (const auto& name : runner.availableAlgorithms()) {
+            const auto levels = runner.availableLevels(name);
+            std::cout << "  - " << name << " [";
+            for (size_t i = 0; i < levels.size(); ++i) {
+                if (i > 0) {
+                    std::cout << ", ";
+                }
+                std::cout << levels[i];
+            }
+            std::cout << "]\n";
+        }
+        return 0;
+    }
+
+    if (!directory.empty()) {
+        appendDirectoryFiles(directory, files);
+    }
+    if (!globPattern.empty()) {
+        auto globbed = globFiles(globPattern);
+        files.insert(files.end(), globbed.begin(), globbed.end());
+    }
+    if (useStdin) {
+        appendStdinFiles(files);
+    }
+    if (files.empty()) {
+        mosqueeze::bench::CorpusManager corpus(corpusPath);
+        corpus.downloadStandardCorpus();
+        for (const auto& file : corpus.listFiles()) {
+            files.push_back(file.path);
+        }
+    }
+    dedupeFiles(files);
+
+    mosqueeze::bench::BenchmarkConfig config;
+    config.files = files;
+    config.useStdin = useStdin;
+    config.corpusPath = corpusPath;
+    config.algorithms = splitCsv(algorithmsOpt);
+    config.levels = splitCsvIntegers(levelsOpt);
+    config.allEngines = allEngines;
+    config.defaultOnly = defaultOnly;
+    config.iterations = iterations;
+    config.warmupIterations = warmup;
+    config.trackMemory = trackMemory;
+    config.runDecode = runDecode;
+    config.maxTimePerFile = std::chrono::seconds(maxTime);
+
+    if (dryRun) {
+        std::cout << "Configuration\n";
+        std::cout << "  files: " << config.files.size() << '\n';
+        std::cout << "  algorithms: " << (config.algorithms.empty() ? "all" : algorithmsOpt) << '\n';
+        std::cout << "  levels: " << (config.levels.empty() ? "engine defaults" : levelsOpt) << '\n';
+        std::cout << "  allEngines: " << (config.allEngines ? "true" : "false") << '\n';
+        std::cout << "  defaultOnly: " << (config.defaultOnly ? "true" : "false") << '\n';
+        std::cout << "  iterations: " << config.iterations << '\n';
+        std::cout << "  warmupIterations: " << config.warmupIterations << '\n';
+        std::cout << "  trackMemory: " << (config.trackMemory ? "true" : "false") << '\n';
+        std::cout << "  runDecode: " << (config.runDecode ? "true" : "false") << '\n';
+        std::cout << "  maxTimePerFile: " << config.maxTimePerFile.count() << "s\n";
+        return 0;
+    }
+
+    if (verbose) {
+        config.onProgress = [&](const mosqueeze::bench::ProgressInfo& info) {
+            const int pct = static_cast<int>(info.progress * 100.0);
+            std::cout << "\r[" << std::setw(3) << pct << "%] "
+                      << info.currentAlgorithm << "/" << info.currentLevel << " "
+                      << info.currentFile.filename().string()
+                      << " iter " << info.currentIteration << "/" << info.totalIterations << std::flush;
+        };
+    }
+
+    const auto startedAt = std::chrono::steady_clock::now();
+    auto results = runner.runWithConfig(config);
+    const auto stats = runner.computeStats(results);
+    const auto finishedAt = std::chrono::steady_clock::now();
+    if (verbose) {
+        std::cout << '\n';
+    }
+
+    std::filesystem::create_directories(outputDir);
+    mosqueeze::bench::ResultsStore store(outputDir / "results.sqlite3");
     store.clear();
     store.saveAll(results);
 
-    if (json) {
-        const auto jsonPath = std::filesystem::path(outputPath) / "results.json";
-        store.exportJson(jsonPath);
-        std::cout << "Exported JSON to " << jsonPath.string() << "\n";
-    }
-    if (csv) {
-        const auto csvPath = std::filesystem::path(outputPath) / "results.csv";
-        store.exportCsv(csvPath);
-        std::cout << "Exported CSV to " << csvPath.string() << "\n";
+    if (!exportFile.empty()) {
+        std::filesystem::create_directories(exportFile.parent_path());
+        if (format == "json") {
+            store.exportJson(exportFile);
+        } else if (format == "csv") {
+            store.exportCsv(exportFile);
+        } else if (format == "markdown") {
+            std::ofstream out(exportFile, std::ios::binary);
+            out << mosqueeze::bench::Formatters::exportMarkdown(results, &stats);
+        } else if (format == "html") {
+            std::ofstream out(exportFile, std::ios::binary);
+            out << mosqueeze::bench::Formatters::exportHtml(results, &stats);
+        }
+    } else {
+        store.exportJson(outputDir / "results.json");
+        store.exportCsv(outputDir / "results.csv");
     }
 
-    std::cout << "\n=== Top 5 by Ratio ===\n";
-    std::sort(results.begin(), results.end(), [](const auto& lhs, const auto& rhs) {
-        return lhs.ratio() > rhs.ratio();
-    });
+    if (!quiet) {
+        const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(finishedAt - startedAt).count();
+        std::cout << "Completed " << results.size() << " benchmark samples in " << elapsed << " ms\n";
+        if (summary || !verbose) {
+            std::cout << mosqueeze::bench::Formatters::formatSummaryTable(results, &stats);
+        } else {
+            for (const auto& row : results) {
+                const auto key = row.algorithm + "/" + std::to_string(row.level);
+                auto it = stats.find(key);
+                std::cout << mosqueeze::bench::Formatters::formatVerbose(
+                    row, it != stats.end() ? &it->second : nullptr) << '\n';
+            }
+        }
+    }
 
-    const size_t topN = std::min<size_t>(results.size(), 5);
-    for (size_t i = 0; i < topN; ++i) {
-        const auto& r = results[i];
-        std::cout << r.algorithm << "/" << r.level << ": "
-                  << r.ratio() << "x (" << r.file.filename().string() << ")\n";
+    if (!compareFile.empty()) {
+        auto previous = loadComparisonRows(compareFile);
+        printComparison(results, previous, diffOnly);
     }
 
     return 0;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -133,3 +133,20 @@ add_custom_command(TARGET AlgorithmSelector_test POST_BUILD
 )
 
 add_test(NAME AlgorithmSelector_test COMMAND AlgorithmSelector_test)
+
+add_executable(BenchmarkConfig_test
+  unit/BenchmarkConfig_test.cpp
+)
+
+target_link_libraries(BenchmarkConfig_test
+  PRIVATE
+    libmosqueeze
+)
+
+add_custom_command(TARGET BenchmarkConfig_test POST_BUILD
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different
+          $<TARGET_FILE:libmosqueeze>
+          $<TARGET_FILE_DIR:BenchmarkConfig_test>
+)
+
+add_test(NAME BenchmarkConfig_test COMMAND BenchmarkConfig_test)

--- a/tests/unit/BenchmarkConfig_test.cpp
+++ b/tests/unit/BenchmarkConfig_test.cpp
@@ -1,0 +1,30 @@
+#include <mosqueeze/bench/BenchmarkConfig.hpp>
+
+#include <cassert>
+#include <iostream>
+
+int main() {
+    mosqueeze::bench::BenchmarkConfig config;
+
+    assert(config.iterations == 1);
+    assert(config.warmupIterations == 0);
+    assert(config.trackMemory);
+    assert(config.runDecode);
+    assert(config.maxTimePerFile.count() == 3600);
+    assert(config.files.empty());
+    assert(!config.useStdin);
+
+    bool called = false;
+    config.onProgress = [&](const mosqueeze::bench::ProgressInfo& info) {
+        called = true;
+        assert(info.currentLevel == 3);
+    };
+
+    mosqueeze::bench::ProgressInfo info{};
+    info.currentLevel = 3;
+    config.onProgress(info);
+    assert(called);
+
+    std::cout << "[PASS] BenchmarkConfig_test\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Add the enhanced `mosqueeze-bench` implementation with config-driven runs, warmup iterations, progress reporting, stats aggregation, exports, and comparison support
- Introduce `BenchmarkConfig`, formatter helpers, and unit coverage for the new config surface
- Update the README and wiki docs to describe the new CLI, outputs, and methodology

## Testing
- Added unit test coverage for `BenchmarkConfig`
- Not run (not requested)