### PR TITLE
Fix benchmark runtime DLL packaging and add --json/--csv flags

### DIFF
--- a/docs/wiki/guides/benchmark-tool.md
+++ b/docs/wiki/guides/benchmark-tool.md
@@ -81,6 +81,8 @@ Output:
   -o, --output DIR
       --export FILE
       --format FORMAT      (json|csv|markdown|html)
+      --json                Export JSON to <output>/results.json
+      --csv                 Export CSV to <output>/results.csv
   -v, --verbose
   -q, --quiet
       --summary
@@ -104,6 +106,9 @@ Misc:
 - Auto-export defaults (when `--export` is not provided):
   - `results.json`
   - `results.csv`
+- Explicit legacy-style export switches are also accepted:
+  - `--json`
+  - `--csv`
 - Optional manual export:
   - `--format markdown` for report-friendly tables
   - `--format html` for browser report + chart
@@ -154,6 +159,16 @@ Notes:
 - Legacy `run()` and `runGrid()` remain supported.
 - Progress callbacks are rate-limited to avoid console flooding.
 - `computeStats(...)` returns aggregated means and standard deviations grouped by `algorithm/level`.
+
+---
+
+## Troubleshooting
+
+On Windows, if `mosqueeze-bench.exe` reports missing DLLs (for example `pugixml.dll`), rebuild the benchmark target so runtime dependencies are copied next to the executable:
+
+```bash
+cmake --build build --config Release --target mosqueeze-bench
+```
 
 ---
 

--- a/src/mosqueeze-bench/CMakeLists.txt
+++ b/src/mosqueeze-bench/CMakeLists.txt
@@ -32,8 +32,19 @@ target_include_directories(mosqueeze-bench
     ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
-add_custom_command(TARGET mosqueeze-bench POST_BUILD
-  COMMAND ${CMAKE_COMMAND} -E copy_if_different
-          $<TARGET_FILE:libmosqueeze>
-          $<TARGET_FILE_DIR:mosqueeze-bench>
-)
+if(WIN32)
+  if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.21")
+    add_custom_command(TARGET mosqueeze-bench POST_BUILD
+      COMMAND ${CMAKE_COMMAND} -E copy_if_different
+              $<TARGET_RUNTIME_DLLS:mosqueeze-bench>
+              $<TARGET_FILE_DIR:mosqueeze-bench>
+      COMMAND_EXPAND_LISTS
+    )
+  else()
+    add_custom_command(TARGET mosqueeze-bench POST_BUILD
+      COMMAND ${CMAKE_COMMAND} -E copy_if_different
+              $<TARGET_FILE:libmosqueeze>
+              $<TARGET_FILE_DIR:mosqueeze-bench>
+    )
+  endif()
+endif()

--- a/src/mosqueeze-bench/src/main.cpp
+++ b/src/mosqueeze-bench/src/main.cpp
@@ -294,6 +294,8 @@ int main(int argc, char* argv[]) {
     std::filesystem::path outputDir{"benchmarks/results"};
     std::filesystem::path exportFile;
     std::string format = "json";
+    bool exportJsonFlag = false;
+    bool exportCsvFlag = false;
     bool verbose = false;
     bool quiet = false;
     bool summary = false;
@@ -332,6 +334,8 @@ int main(int argc, char* argv[]) {
     app.add_option("--export", exportFile, "Export results to file");
     app.add_option("--format", format, "Export format: json,csv,markdown,html")
         ->check(CLI::IsMember({"json", "csv", "markdown", "html"}));
+    app.add_flag("--json", exportJsonFlag, "Export JSON to <output>/results.json");
+    app.add_flag("--csv", exportCsvFlag, "Export CSV to <output>/results.csv");
     app.add_flag("-v,--verbose", verbose, "Verbose console output with progress");
     app.add_flag("-q,--quiet", quiet, "Quiet mode (errors only)");
     app.add_flag("--summary", summary, "Print summary table only");
@@ -475,9 +479,27 @@ int main(int argc, char* argv[]) {
             std::ofstream out(exportFile, std::ios::binary);
             out << mosqueeze::bench::Formatters::exportHtml(results, &stats);
         }
-    } else {
-        store.exportJson(outputDir / "results.json");
-        store.exportCsv(outputDir / "results.csv");
+    }
+
+    if (exportFile.empty()) {
+        if (exportJsonFlag || exportCsvFlag) {
+            if (exportJsonFlag) {
+                store.exportJson(outputDir / "results.json");
+            }
+            if (exportCsvFlag) {
+                store.exportCsv(outputDir / "results.csv");
+            }
+        } else {
+            store.exportJson(outputDir / "results.json");
+            store.exportCsv(outputDir / "results.csv");
+        }
+    } else if (exportJsonFlag || exportCsvFlag) {
+        if (exportJsonFlag) {
+            store.exportJson(outputDir / "results.json");
+        }
+        if (exportCsvFlag) {
+            store.exportCsv(outputDir / "results.csv");
+        }
     }
 
     if (!quiet) {

--- a/src/mosqueeze-cli/CMakeLists.txt
+++ b/src/mosqueeze-cli/CMakeLists.txt
@@ -14,8 +14,19 @@ target_link_libraries(mosqueeze
     spdlog::spdlog
 )
 
-add_custom_command(TARGET mosqueeze POST_BUILD
-  COMMAND ${CMAKE_COMMAND} -E copy_if_different
-          $<TARGET_FILE:libmosqueeze>
-          $<TARGET_FILE_DIR:mosqueeze>
-)
+if(WIN32)
+  if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.21")
+    add_custom_command(TARGET mosqueeze POST_BUILD
+      COMMAND ${CMAKE_COMMAND} -E copy_if_different
+              $<TARGET_RUNTIME_DLLS:mosqueeze>
+              $<TARGET_FILE_DIR:mosqueeze>
+      COMMAND_EXPAND_LISTS
+    )
+  else()
+    add_custom_command(TARGET mosqueeze POST_BUILD
+      COMMAND ${CMAKE_COMMAND} -E copy_if_different
+              $<TARGET_FILE:libmosqueeze>
+              $<TARGET_FILE_DIR:mosqueeze>
+    )
+  endif()
+endif()


### PR DESCRIPTION
## Summary
- fix Windows runtime packaging for \mosqueeze-bench\ and \mosqueeze\ by copying transitive runtime DLL dependencies with \TARGET_RUNTIME_DLLS\
- add \--json\ and \--csv\ benchmark CLI flags as compatibility aliases that export to \<output>/results.json\ and \<output>/results.csv\
- update benchmark guide docs with the new flags and a Windows missing-DLL troubleshooting note

## Why
- resolves runtime launch failures such as missing \pugixml.dll\ when running \mosqueeze-bench.exe\ from \Release\
- accepts existing command usage that included \--json --csv\

## Validation
- rebuilt Release targets for \mosqueeze-bench\ and \mosqueeze\
- verified runtime DLLs are present in output directories
- verified \mosqueeze-bench --help\ shows \--json\ and \--csv\
- ran \ctest --test-dir build -C Release --output-on-failure\ (all tests passed)
