### PR TITLE
Worker specs for benchmark improvements (#35, #36, #38)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Dependencies are declared in `vcpkg.json`:
 - fmt
 - spdlog
 - nlohmann-json
+- sqlite3
+- pugixml
 
 ## Build
 
@@ -51,6 +53,9 @@ mosqueeze v0.1.0
 # Benchmark a directory with multiple iterations
 ./build/src/mosqueeze-bench/mosqueeze-bench --directory ./benchmarks/corpus --iterations 5 --warmup 2 --summary
 
+# Parallel run with explicit thread count + JSON/CSV exports
+./build/src/mosqueeze-bench/mosqueeze-bench --directory ./benchmarks/corpus --threads 8 --output ./benchmarks/results --json --csv
+
 # Export HTML report
 ./build/src/mosqueeze-bench/mosqueeze-bench --directory ./benchmarks/corpus --export ./benchmarks/results/report.html --format html
 ```
@@ -72,6 +77,7 @@ ctest --output-on-failure
 - [FileType → Algorithm Mapping](docs/wiki/decisions/file-type-to-algorithm.md) — Decision guide
 - [Benchmark Results](docs/wiki/benchmarks/graphs/ratio-by-algorithm.md) — Performance data
 - [Benchmark Tool Guide](docs/wiki/guides/benchmark-tool.md) — Full `mosqueeze-bench` CLI and exports
+- [Preprocessing Guide](docs/wiki/preprocessing.md) — Current preprocessors and trailing header format
 - [Getting Started Guide](docs/wiki/guides/getting-started.md) — Full setup instructions
 
 ## License

--- a/docs/features/feat-35-raw-metadata-stripper.md
+++ b/docs/features/feat-35-raw-metadata-stripper.md
@@ -1,0 +1,378 @@
+# Worker Spec: Extend ImageMetaStripper to RAW Formats
+
+**Issue:** #35  
+**Branch:** `feat/benchmark-improvements`  
+**Priority:** Medium  
+**Type:** Enhancement
+
+---
+
+## Problem Statement
+
+The current `ImageMetaStripper` preprocessor handles JPEG/PNG metadata but does not support RAW image formats which are TIFF-based containers:
+
+| Format | Vendor | Container Type |
+|--------|--------|----------------|
+| `.raf` | Fujifilm | TIFF-based proprietary |
+| `.nef` | Nikon | TIFF-EP |
+| `.cr2`/`.cr3` | Canon | TIFF-based |
+| `.dng` | Adobe | TIFF-EP (standard) |
+| `.arw` | Sony | TIFF-based |
+| `.orf` | Olympus | TIFF-based |
+
+## Why This Matters
+
+RAW files contain significant metadata that is highly compressible:
+- EXIF block: ~50-200 KB
+- Maker notes: Vendor-specific data
+- Preview JPEGs: Often multiple sizes (thumbnail, preview)
+- IPTC/XMP: Sidecar metadata
+
+Stripping this metadata before compression can:
+1. Remove ~50-200 KB per file
+2. Enable better compression ratios on the actual Bayer sensor data
+3. Preserve raw pixel data while reducing file size
+
+---
+
+## TIFF Container Structure
+
+### Standard TIFF Structure
+```
+Offset 0:     TIFF Header (8 bytes)
+              - Byte order: 'II' (little-endian) or 'MM' (big-endian)
+              - Magic: 42
+              - IFD0 offset
+
+IFD0:         Image File Directory
+              - Tag count
+              - Tags (width, height, compression, strips, etc.)
+              - Next IFD offset
+
+Additional IFDs: Thumbnails, previews, EXIF, etc.
+```
+
+### RAW-Specific IFDs
+```
+IFD0:         Main image metadata
+SubIFD:       Preview/thumbnail
+EXIF IFD:     Camera settings
+MakerNotes:   Vendor-specific (Nikon, Canon, etc.)
+GPUrams:      Gamma correction tables
+CFAPattern:   Bayer color filter array
+```
+
+---
+
+## Implementation Plan
+
+### Phase 1: FileTypeDetector Extension
+
+**File:** `src/libmosqueeze/src/FileTypeDetector.cpp`
+
+Add detection for TIFF-based RAW formats:
+
+```cpp
+// In detect() function, add TIFF-based detection
+if (hasMagick(file, {0x49, 0x49, 0x2A, 0x00})) {  // "II*\0" - little-endian TIFF
+    return classifyTiffBased(file);
+}
+if (hasMagick(file, {0x4D, 0x4D, 0x00, 0x2A})) {  // "MM\0*" - big-endian TIFF
+    return classifyTiffBased(file);
+}
+
+// New helper function
+FileType classifyTiffBased(const std::filesystem::path& file) {
+    std::string ext = file.extension().string();
+    std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
+    
+    if (ext == ".nef" || ext == ".nrw") return FileType::NikonRaw;
+    if (ext == ".cr2" || ext == ".cr3") return FileType::CanonRaw;
+    if (ext == ".raf") return FileType::FujifilmRaw;
+    if (ext == ".arw" || ext == ".sr2") return FileType::SonyRaw;
+    if (ext == ".dng") return FileType::DNG;
+    if (ext == ".orf") return FileType::OlympusRaw;
+    if (ext == ".rw2") return FileType::PanasonicRaw;
+    
+    return FileType::Tiff;  // Generic TIFF
+}
+```
+
+**File:** `src/libmosqueeze/include/mosqueeze/FileTypeDetector.hpp`
+
+Add new FileType enum values:
+```cpp
+enum class FileType {
+    Unknown,
+    Jpeg,
+    Png,
+    Tiff,
+    // RAW formats
+    NikonRaw,
+    CanonRaw,
+    FujifilmRaw,
+    SonyRaw,
+    DNG,
+    OlympusRaw,
+    PanasonicRaw,
+    // ... existing types ...
+};
+```
+
+### Phase 2: ImageMetaStripper Extension
+
+**File:** `src/libmosqueeze/src/preprocessors/ImageMetaStripper.cpp`
+
+Add TIFF/RAW metadata stripping:
+
+```cpp
+std::vector<uint8_t> ImageMetaStripper::process(const std::vector<uint8_t>& data, FileType type) {
+    switch (type) {
+        case FileType::Jpeg:
+        case FileType::Png:
+            return stripImageMetadata(data, type);
+        
+        case FileType::NikonRaw:
+        case FileType::CanonRaw:
+        case FileType::FujifilmRaw:
+        case FileType::DNG:
+        case FileType::SonyRaw:
+        case FileType::OlympusRaw:
+        case FileType::PanasonicRaw:
+            return stripRawMetadata(data, type);
+        
+        default:
+            return data;  // Pass through unsupported types
+    }
+}
+
+std::vector<uint8_t> ImageMetaStripper::stripRawMetadata(
+    const std::vector<uint8_t>& data, 
+    FileType type
+) {
+    // Parse TIFF header
+    if (data.size() < 8) return data;
+    
+    bool littleEndian = (data[0] == 'I' && data[1] == 'I');
+    uint32_t ifdOffset = readU32(data, 4, littleEndian);
+    
+    // Build list of essential tags to preserve
+    std::set<uint16_t> preserveTags = {
+        256, 257, 258, 259,  // Width, Height, BitsPerSample, Compression
+        273, 277, 278, 279,  // StripOffsets, SamplesPerPixel, RowsPerStrip, StripByteCounts
+        339,                 // SampleFormat
+        // RAW-specific
+        0x828D,              // CFARepeatPatternDim
+        0x828E,              // CFAPattern
+        0x828F,              // ExposureTime
+        // ... essential RAW tags
+    };
+    
+    // Remove tags from preserve set:
+    // - EXIF IFD (tag 34665)
+    // - GPS IFD (tag 34853)
+    // - MakerNotes (inside EXIF)
+    // - Interop IFD (tag 40965)
+    // - Preview IFDs
+    
+    // Rebuild TIFF with stripped metadata
+    // ...
+}
+```
+
+### Phase 3: TIFF Parser Helper
+
+**File:** `src/libmosqueeze/src/preprocessors/TiffParser.hpp` (new file)
+
+```cpp
+namespace mosqueeze {
+
+struct TiffTag {
+    uint16_t tagId;
+    uint16_t type;
+    uint32_t count;
+    uint32_t valueOrOffset;
+};
+
+class TiffParser {
+public:
+    explicit TiffParser(const std::vector<uint8_t>& data);
+    
+    bool isValid() const;
+    bool isLittleEndian() const { return littleEndian_; }
+    
+    std::vector<TiffTag> readIfd(uint32_t offset);
+    uint32_t readU32(uint32_t offset) const;
+    uint16_t readU16(uint32_t offset) const;
+    
+    // Find IFD by tag ID
+    std::optional<uint32_t> findIfdOffset(uint16_t ifdTag);
+    
+    // Get tag value
+    std::optional<TiffTag> getTag(uint16_t tagId, uint32_t ifdOffset);
+    
+    // Strip specific tags and rebuild
+    std::vector<uint8_t> stripTags(
+        const std::set<uint16_t>& tagsToRemove,
+        const std::set<uint16_t>& ifdsToRemove
+    );
+    
+private:
+    const std::vector<uint8_t>& data_;
+    bool littleEndian_;
+};
+
+} // namespace mosqueeze
+```
+
+---
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `src/libmosqueeze/include/mosqueeze/FileTypeDetector.hpp` | Add RAW FileType enums |
+| `src/libmosqueeze/src/FileTypeDetector.cpp` | Add TIFF/RAW detection |
+| `src/libmosqueeze/src/preprocessors/ImageMetaStripper.cpp` | Add RAW stripping logic |
+| `src/libmosqueeze/src/preprocessors/TiffParser.hpp` | TIFF parsing utilities |
+| `src/libmosqueeze/src/preprocessors/TiffParser.cpp` | TIFF parsing implementation |
+| `tests/unit/ImageMetaStripper_test.cpp` | Add RAW test cases |
+
+---
+
+## Testing Plan
+
+### Unit Tests
+
+```cpp
+TEST(ImageMetaStripper, DetectsNefFiles) {
+    FileTypeDetector detector;
+    auto result = detector.detect("test.nef");
+    EXPECT_EQ(result.type, FileType::NikonRaw);
+}
+
+TEST(ImageMetaStripper, DetectsRafFiles) {
+    FileTypeDetector detector;
+    auto result = detector.detect("test.raf");
+    EXPECT_EQ(result.type, FileType::FujifilmRaw);
+}
+
+TEST(ImageMetaStripper, DetectsDngFiles) {
+    FileTypeDetector detector;
+    auto result = detector.detect("test.dng");
+    EXPECT_EQ(result.type, FileType::DNG);
+}
+
+TEST(ImageMetaStripper, StripsNefMetadata) {
+    std::vector<uint8_t> nefData = loadTestFile("test.nef");
+    ImageMetaStripper stripper;
+    auto result = stripper.process(nefData, FileType::NikonRaw);
+    
+    EXPECT_LT(result.size(), nefData.size());  // Should be smaller
+    // Verify original size preserved (Bayer data)
+}
+
+TEST(TiffParser, ReadsIfd) {
+    TiffParser parser(loadTestFile("test.nef"));
+    EXPECT_TRUE(parser.isValid());
+    
+    auto tags = parser.readIfd(8);  // IFD0 typically at offset 8
+    EXPECT_FALSE(tags.empty());
+}
+
+TEST(TiffParser, StripsExifIfd) {
+    // Verify EXIF IFD is removable
+}
+```
+
+### Integration Tests
+
+```bash
+# Test with actual RAW files
+mosqueeze-bench -f "test.nef" --default-only -v -o "./results"
+mosqueeze-bench -f "test.raf" --default-only -v -o "./results"
+mosqueeze-bench -f "test.dng" --default-only -v -o "./results"
+```
+
+### Test Data Requirements
+
+Need sample RAW files for testing:
+- `test.nef` — Nikon NEF sample (can use public test images)
+- `test.raf` — Fujifilm RAF sample
+- `test.dng` — Adobe DNG sample
+- `test.cr2` — Canon CR2 sample
+
+---
+
+## Implementation Phases
+
+### Phase 1: Detection (1 day)
+- Add FileType enums for RAW formats
+- Implement TIFF magic number detection
+- Verify file extension correlation
+
+### Phase 2: TIFF Parsing (2 days)
+- Implement TiffParser class
+- Handle both endianness
+- Read/write IFD structures
+
+### Phase 3: Metadata Stripping (2 days)
+- Identify non-essential IFDs (EXIF, GPS, Preview, MakerNotes)
+- Implement strip logic
+- Rebuild TIFF structure
+
+### Phase 4: Testing (1 day)
+- Unit tests for each format
+- Roundtrip verification
+- Compression comparison
+
+---
+
+## Verification Checklist
+
+- [ ] FileTypeDetector correctly identifies NEF, RAF, CR2, DNG
+- [ ] ImageMetaStripper processes RAW files without error
+- [ ] Stripped files are smaller than originals
+- [ ] Bayer data is preserved (image data intact)
+- [ ] Roundtrip: original → strip → compress → decompress → restore
+- [ ] Tests pass for all supported RAW formats
+
+---
+
+## Dependencies
+
+- PR #32 (Preprocessing Engine) — already merged
+
+---
+
+## Risks
+
+1. **Vendor-specific variations:** Each RAW format has proprietary extensions
+   - Mitigation: Start with DNG (standardized), then add vendor-specific
+
+2. **Metadata preservation:** Some metadata may be needed for image processing
+   - Mitigation: Make stripping configurable (keep EXIF, remove previews, etc.)
+
+3. **File corruption risk:** Incorrect TIFF editing can render files unreadable
+   - Mitigation: Extensive testing, roundtrip verification
+
+---
+
+## Estimated Effort
+
+| Task | Time |
+|------|------|
+| Phase 1: Detection | 1 day |
+| Phase 2: TIFF Parser | 2 days |
+| Phase 3: Stripping | 2 days |
+| Phase 4: Testing | 1 day |
+| **Total** | **6 days** |
+
+---
+
+## References
+
+- [TIFF 6.0 Specification](https://www.adobe.io/open/document-format/pdf/1658705319505/TIFF-6.0.pdf)
+- [TIFF/EP Specification](https://www.iso.org/standard/41876.html)
+- [DNG Specification](https://www.adobe.io/content/dam/dw/1658705319505/dng/dng_spec_1.6.pdf)
+- [ExifTool RAW format documentation](https://exiftool.org/TagNames/)

--- a/docs/features/feat-36-bayer-preprocessor.md
+++ b/docs/features/feat-36-bayer-preprocessor.md
@@ -1,0 +1,515 @@
+# Worker Spec: RAW Bayer Preprocessor for Improved Compression
+
+**Issue:** #36  
+**Branch:** `feat/benchmark-improvements`  
+**Priority:** Low  
+**Type:** Enhancement (Optimization)
+
+---
+
+## Problem Statement
+
+RAW image files contain uncompressed Bayer pattern sensor data. The RGGB (or similar) pattern has predictable spatial structure that generic compressors don't exploit efficiently.
+
+### Bayer Pattern Background
+
+Camera sensors use a Bayer filter mosaic:
+
+```
+R  G1  R  G1  R  G1 ...
+G2 B   G2 B   G2 B ...
+R  G1  R  G1  R  G1 ...
+G2 B   G2 B   G2 B ...
+```
+
+Each cell is a 2×2 block with pattern R-G1 / G2-B. This regular structure offers compression opportunities:
+
+1. **Predictable pattern:** Color channels can be separated
+2. **Spatial correlation:** Adjacent pixels of same color have similar values
+3. **Delta encoding:** Differences between neighbors are smaller than absolute values
+4. **Bit packing:** 14-bit values often stored as 16-bit with padding
+
+## Potential Compression Improvement
+
+| Compressor | Current (raw file) | With Bayer Preproc | Improvement |
+|------------|-------------------|-------------------|-------------|
+| Zstd | 1.05-1.10x | 1.20-1.30x | +10-20% |
+| LZMA | 1.08-1.12x | 1.25-1.35x | +12-20% |
+| ZPAQ | 1.10-1.15x | 1.30-1.45x | +15-25% |
+
+---
+
+## Bayer Pattern Variations
+
+| Pattern | Cameras | Arrangement |
+|---------|----------|--------------|
+| RGGB | Most common | Canon, Nikon, Sony |
+| GRBG | Some Nikons | Rotated 90° |
+| GBRG | Some cameras | Different G positions |
+| BGGR | Fuji X-Trans variants | Blue-first |
+
+The preprocessor must detect the pattern from CFA (Color Filter Array) metadata.
+
+---
+
+## Implementation Plan
+
+### Phase 1: Research & Design
+
+Before implementation, research existing approaches:
+
+1. **JPEG XL modular mode** — Uses MA-like context modeling for Bayer
+2. **FLIF** — Uses MANIAC trees with near-lossless preprocessing
+3. **libraw** — Reference for Bayer pattern extraction
+4. **DNG SDK** — Adobe's reference for RAW handling
+
+Key decisions:
+- Pattern detection from metadata vs heuristic detection
+- Bit depth handling (12-bit, 14-bit, 16-bit)
+- Reversibility requirements (lossless reconstruction)
+- Performance requirements (streaming vs full-buffer)
+
+### Phase 2: BayerPreprocessor Interface
+
+**File:** `src/libmosqueeze/include/mosqueeze/preprocessors/BayerPreprocessor.hpp`
+
+```cpp
+#pragma once
+
+#include <mosqueeze/Preprocessor.hpp>
+#include <mosqueeze/FileTypeDetector.hpp>
+#include <cstdint>
+#include <vector>
+#include <optional>
+#include <array>
+
+namespace mosqueeze {
+
+/**
+ * @brief Bayer filter pattern types
+ */
+enum class BayerPattern {
+    RGGB,   // Most common: R-G-G-B
+    GRBG,   // Rotated: G-R-B-G
+    GBRG,   // Alternative: G-B-R-G
+    BGGR,   // Inverted: B-G-G-R
+    Unknown // Pattern could not be determined
+};
+
+/**
+ * @brief RAW image metadata extracted from TIFF/DNG
+ */
+struct RawMetadata {
+    uint32_t width;
+    uint32_t height;
+    uint16_t bitsPerSample;        // Typically 12, 14, or 16
+    uint16_t samplesPerPixel;      // Usually 1 for RAW
+    BayerPattern pattern;
+    uint16_t blackLevel;           // Sensor black level
+    uint16_t whiteLevel;           // Sensor white level
+    std::array<uint16_t, 4> cfaRepeatPattern; // CFA dimensions
+};
+
+/**
+ * @brief Preprocessor for RAW Bayer sensor data
+ * 
+ * This preprocessor improves compression by:
+ * 1. Separating color channels (R, G1, G2, B)
+ * 2. Applying delta encoding within each channel
+ * 3. Deinterleaving bits for better entropy coding
+ * 
+ * The transformation is reversible and lossless.
+ */
+class BayerPreprocessor : public IPreprocessor {
+public:
+    BayerPreprocessor() = default;
+    ~BayerPreprocessor() override = default;
+
+    /**
+     * @brief Process RAW data to improve compressibility
+     * @param data Raw Bayer data
+     * @param metadata RAW metadata including pattern detection
+     * @return Transformed data ready for compression
+     */
+    std::vector<uint8_t> process(
+        const std::vector<uint8_t>& data,
+        const RawMetadata& metadata
+    );
+
+    /**
+     * @brief Reverse the preprocessing after decompression
+     * @param data Compressed and then decompressed data
+     * @param metadata RAW metadata (must be same as preprocessing)
+     * @return Original Bayer data
+     */
+    std::vector<uint8_t> reverse(
+        const std::vector<uint8_t>& data,
+        const RawMetadata& metadata
+    );
+
+    /**
+     * @brief Detect Bayer pattern from metadata
+     * @param data RAW file data (TIFF/DNG format)
+     * @return Detected pattern, or Unknown if not found
+     */
+    static BayerPattern detectPattern(const std::vector<uint8_t>& data);
+
+    /**
+     * @brief Extract RAW metadata from TIFF/DNG
+     * @param data RAW file data
+     * @return Metadata structure, or nullopt if extraction fails
+     */
+    static std::optional<RawMetadata> extractMetadata(const std::vector<uint8_t>& data);
+
+    std::string name() const override { return "BayerPreprocessor"; }
+
+private:
+    /**
+     * @brief Separate interleaved Bayer data into color channels
+     * @param data Raw interleaved Bayer data
+     * @param width Image width
+     * @param height Image height
+     * @param pattern Bayer pattern type
+     * @return Array of 4 channels: [R, G1, G2, B]
+     */
+    std::array<std::vector<uint16_t>, 4> separateChannels(
+        const std::vector<uint8_t>& data,
+        uint32_t width,
+        uint32_t height,
+        BayerPattern pattern
+    );
+
+    /**
+     * @brief Apply delta encoding to a channel
+     * @param channel Input pixel values
+     * @param width Channel width (original_width / 2)
+     * @param height Channel height (original_height / 2)
+     * @return Delta-encoded values (smaller range, better entropy)
+     */
+    std::vector<int16_t> deltaEncode(
+        const std::vector<uint16_t>& channel,
+        uint32_t width,
+        uint32_t height
+    );
+
+    /**
+     * @brief Reverse delta encoding
+     */
+    std::vector<uint16_t> deltaDecode(
+        const std::vector<int16_t>& deltaChannel,
+        uint32_t width,
+        uint32_t height
+    );
+
+    /**
+     * @brief Interleave separated channels back into Bayer format
+     */
+    std::vector<uint8_t> interleaveChannels(
+        const std::array<std::vector<uint16_t>, 4>& channels,
+        uint32_t width,
+        uint32_t height,
+        BayerPattern pattern
+    );
+};
+
+} // namespace mosqueeze
+```
+
+### Phase 3: Implementation
+
+**File:** `src/libmosqueeze/src/preprocessors/BayerPreprocessor.cpp`
+
+```cpp
+#include "mosqueeze/preprocessors/BayerPreprocessor.hpp"
+#include <algorithm>
+#include <cmath>
+
+namespace mosqueeze {
+
+BayerPattern BayerPreprocessor::detectPattern(const std::vector<uint8_t>& data) {
+    // Parse TIFF CFARepeatPatternDim tag (0x828D)
+    // Standard patterns:
+    // - [2, 2, R, G, G, B] → RGGB
+    // - [2, 2, G, R, B, G] → GRBG
+    // - [2, 2, G, B, R, G] → GBRG
+    // - [2, 2, B, G, G, R] → BGGR
+    
+    // Implementation requires TIFF parsing
+    // See TiffParser from Issue #35
+    return BayerPattern::Unknown;
+}
+
+std::optional<RawMetadata> BayerPreprocessor::extractMetadata(
+    const std::vector<uint8_t>& data
+) {
+    // Use TiffParser to extract:
+    // - Width (tag 256)
+    // - Height (tag 257)
+    // - BitsPerSample (tag 258)
+    // - CFARepeatPatternDim (tag 0x828D)
+    // - CFAPattern (tag 0x828E)
+    
+    return std::nullopt; // Placeholder
+}
+
+std::vector<uint8_t> BayerPreprocessor::process(
+    const std::vector<uint8_t>& data,
+    const RawMetadata& metadata
+) {
+    // Step 1: Separate channels
+    auto channels = separateChannels(
+        data,
+        metadata.width,
+        metadata.height,
+        metadata.pattern
+    );
+
+    // Step 2: Delta encode each channel
+    std::array<std::vector<int16_t>, 4> deltaChannels;
+    for (int i = 0; i < 4; ++i) {
+        deltaChannels[i] = deltaEncode(
+            channels[i],
+            metadata.width / 2,
+            metadata.height / 2
+        );
+    }
+
+    // Step 3: Pack into output format
+    std::vector<uint8_t> result;
+    // ... implementation
+    
+    return result;
+}
+
+std::vector<uint8_t> BayerPreprocessor::reverse(
+    const std::vector<uint8_t>& data,
+    const RawMetadata& metadata
+) {
+    // Reverse: unpack → delta decode → interleave
+    // ... implementation
+    return {};
+}
+
+std::array<std::vector<uint16_t>, 4> BayerPreprocessor::separateChannels(
+    const std::vector<uint8_t>& data,
+    uint32_t width,
+    uint32_t height,
+    BayerPattern pattern
+) {
+    std::array<std::vector<uint16_t>, 4> channels;
+    
+    // Each channel is width/2 × height/2
+    size_t channelSize = (width / 2) * (height / 2);
+    for (int i = 0; i < 4; ++i) {
+        channels[i].reserve(channelSize);
+    }
+
+    // Extract pixels based on pattern
+    // RGGB: R at (0,0), G at (0,1), G at (1,0), B at (1,1)
+    for (uint32_t y = 0; y < height; y += 2) {
+        for (uint32_t x = 0; x < width; x += 2) {
+            size_t idx = (y * width + x) * 2; // 16-bit pixels
+            uint16_t p0 = data[idx] | (data[idx + 1] << 8);
+            uint16_t p1 = data[(y * width + x + 1) * 2];
+            uint16_t p2 = data[((y + 1) * width + x) * 2];
+            uint16_t p3 = data[((y + 1) * width + x + 1) * 2];
+            
+            // Assign to channels based on pattern
+            switch (pattern) {
+                case BayerPattern::RGGB:
+                    channels[0].push_back(p0); // R
+                    channels[1].push_back(p1); // G1
+                    channels[2].push_back(p2); // G2
+                    channels[3].push_back(p3); // B
+                    break;
+                // ... other patterns
+            }
+        }
+    }
+
+    return channels;
+}
+
+std::vector<int16_t> BayerPreprocessor::deltaEncode(
+    const std::vector<uint16_t>& channel,
+    uint32_t width,
+    uint32_t height
+) {
+    std::vector<int16_t> delta;
+    delta.reserve(channel.size());
+
+    // Simple delta: current - previous (row-major order)
+    // More sophisticated: gradient prediction using left + above - diagonal
+    
+    uint16_t prev = channel[0];
+    delta.push_back(static_cast<int16_t>(prev)); // First pixel as-is
+
+    for (size_t i = 1; i < channel.size(); ++i) {
+        int32_t diff = static_cast<int32_t>(channel[i]) - static_cast<int32_t>(prev);
+        delta.push_back(static_cast<int16_t>(diff));
+        prev = channel[i];
+    }
+
+    return delta;
+}
+
+} // namespace mosqueeze
+```
+
+### Phase 4: Integration
+
+**File:** `src/libmosqueeze/src/PreprocessorSelector.cpp`
+
+Add Bayer preprocessor registration:
+
+```cpp
+#include "mosqueeze/preprocessors/BayerPreprocessor.hpp"
+
+// In PreprocessorSelector::select()
+if (fileType == FileType::NikonRaw ||
+    fileType == FileType::CanonRaw ||
+    fileType == FileType::FujifilmRaw ||
+    fileType == FileType::DNG ||
+    fileType == FileType::SonyRaw) {
+    
+    preprocessor = std::make_unique<BayerPreprocessor>();
+}
+```
+
+---
+
+## Files to Create/Modify
+
+| File | Action |
+|------|--------|
+| `src/libmosqueeze/include/mosqueeze/preprocessors/BayerPreprocessor.hpp` | Create |
+| `src/libmosqueeze/src/preprocessors/BayerPreprocessor.cpp` | Create |
+| `src/libmosqueeze/src/PreprocessorSelector.cpp` | Modify (add registration) |
+| `tests/unit/BayerPreprocessor_test.cpp` | Create |
+
+---
+
+## Testing Plan
+
+### Unit Tests
+
+```cpp
+TEST(BayerPreprocessor, DetectsPatternRGGB) {
+    std::vector<uint8_t> dng = loadDngWithPattern(BayerPattern::RGGB);
+    EXPECT_EQ(BayerPreprocessor::detectPattern(dng), BayerPattern::RGGB);
+}
+
+TEST(BayerPreprocessor, SeparatesChannelsCorrect) {
+    // Create 4x4 Bayer image: RGGB pattern
+    std::vector<uint16_t> bayer = {
+        100, 200, 110, 210,  // Row 0: R G R G
+        150, 250, 160, 260,  // Row 1: G B G B
+        105, 205, 115, 215,  // Row 2: R G R G
+        155, 255, 165, 265   // Row 3: G B G B
+    };
+    
+    BayerPreprocessor preproc;
+    auto channels = preproc.separateChannels(bayer, 4, 4, BayerPattern::RGGB);
+    
+    EXPECT_EQ(channels[0].size(), 4); // R channel: 100, 110, 105, 115
+    EXPECT_EQ(channels[3].size(), 4); // B channel: 250, 260, 255, 265
+}
+
+TEST(BayerPreprocessor, DeltaEncodeReducesEntropy) {
+    std::vector<uint16_t> constant(100, 1000);
+    auto delta = BayerPreprocessor::deltaEncode(constant, 10, 10);
+    
+    // All deltas should be 0 (or near 0)
+    EXPECT_NEAR(delta[1], 0, 1);
+}
+
+TEST(BayerPreprocessor, RoundtripPreservesData) {
+    std::vector<uint8_t> original = loadTestRaw("test.nef");
+    RawMetadata meta = *BayerPreprocessor::extractMetadata(original);
+    
+    BayerPreprocessor preproc;
+    auto processed = preproc.process(original, meta);
+    auto restored = preproc.reverse(processed, meta);
+    
+    EXPECT_EQ(original, restored);
+}
+```
+
+### Integration Test with Compression
+
+```cpp
+TEST(BayerPreprocessor, ImprovesCompressionRatio) {
+    std::vector<uint8_t> raw = loadTestRaw("test.nef");
+    
+    // Compress without preprocessing
+    ZstdEngine zstd;
+    auto result1 = zstd.compress(raw, CompressionOptions{.level = 22});
+    double ratio1 = static_cast<double>(raw.size()) / result1.compressedBytes;
+    
+    // Compress with preprocessing
+    BayerPreprocessor preproc;
+    RawMetadata meta = *BayerPreprocessor::extractMetadata(raw);
+    auto preprocessed = preproc.process(raw, meta);
+    
+    auto result2 = zstd.compress(preprocessed, CompressionOptions{.level = 22});
+    double ratio2 = static_cast<double>(raw.size()) / result2.compressedBytes;
+    
+    EXPECT_GT(ratio2, ratio1); // Preprocessed should compress better
+}
+```
+
+---
+
+## Dependencies
+
+| Dependency | Status |
+|------------|--------|
+| Issue #35 (RAW format detection) | Required — needs TiffParser |
+| PR #32 (Preprocessing Engine) | Merged — provides framework |
+
+---
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Pattern detection fails | Fall back to no preprocessing |
+| Performance overhead | Benchmark acceptable limits, optimize later |
+| Non-standard patterns | Support common patterns first, extend later |
+| Memory usage for large RAWs | Stream processing in chunks |
+
+---
+
+## Implementation Phases
+
+| Phase | Task | Duration |
+|-------|------|----------|
+| 1 | Research existing implementations | 2 days |
+| 2 | BayerPreprocessor interface + tests | 1 day |
+| 3 | Pattern detection with TiffParser | 2 days |
+| 4 | Delta encoding + channel separation | 2 days |
+| 5 | Integration + benchmarking | 2 days |
+| **Total** | | **9 days** |
+
+---
+
+## Verification Checklist
+
+- [ ] Pattern detection works for RGGB, GRBG, GBRG, BGGR
+- [ ] Metadata extraction from NEF, RAF, CR2, DNG
+- [ ] Channel separation produces correct dimensions
+- [ ] Delta encoding reduces entropy
+- [ ] Roundtrip is lossless
+- [ ] Compression ratio improves by measurable amount
+- [ ] Performance is acceptable (< 100ms for typical RAW)
+- [ ] Integration with PreprocessorSelector works
+
+---
+
+## References
+
+- [Bayer filter - Wikipedia](https://en.wikipedia.org/wiki/Bayer_filter)
+- [JPEG XL modular mode](https://google.github.io/au/jpegxl/#modular-mode) — context modeling
+- [FLIF compression](https://flif.info/spec.html) — MANIAC trees
+- [DNG 1.6 Specification](https://www.adobe.io/content/dam/dw/1658705319505/dng/dng_spec_1.6.pdf) — CFA tags
+- [libraw source](https://github.com/LibRaw/LibRaw) — reference implementation

--- a/docs/features/feat-38-disable-parallel-memory-tracking.md
+++ b/docs/features/feat-38-disable-parallel-memory-tracking.md
@@ -1,0 +1,202 @@
+# Worker Spec: Disable Memory Tracking in Parallel Benchmark Mode
+
+**Issue:** #38  
+**Branch:** `feat/benchmark-improvements`  
+**Priority:** Medium  
+**Type:** Bug fix
+
+---
+
+## Problem Statement
+
+Memory tracking in parallel benchmarks reports meaningless values (~5.4 GB per file) because `getPeakMemoryUsage()` measures the **entire process working set**, not per-operation memory.
+
+### Root Cause
+
+```cpp
+// src/libmosqueeze/src/platform/Platform.cpp
+size_t getPeakMemoryUsage() {
+#if defined(MOSQUEEZE_WINDOWS)
+    PROCESS_MEMORY_COUNTERS counters{};
+    GetProcessMemoryInfo(GetCurrentProcess(), &counters, sizeof(counters));
+    return counters.PeakWorkingSetSize;  // ← Process-wide, not per-thread
+#endif
+}
+```
+
+With 8 threads running concurrently:
+- All engine libraries (Zstd, LZMA, Brotli, ZPAQ) are loaded
+- Each thread allocates buffers
+- Working set accumulates across all threads
+- Final measurement shows total process memory, not per-file usage
+
+### Evidence from Benchmark
+
+| Algorithm | Avg Memory Reported | Avg File Size | Reality |
+|-----------|---------------------|---------------|---------|
+| zstd | 5,389 MB | 177 KB | Wrong — should be ~1-5 MB |
+| xz | 5,389 MB | 177 KB | Wrong |
+| brotli | 5,389 MB | 177 KB | Wrong |
+| zpaq | 5,389 MB | 177 KB | Wrong |
+
+All show identical memory because it's the cumulative process working set.
+
+---
+
+## Implementation Plan
+
+### Step 1: Disable memory tracking in `runParallel()`
+
+**File:** `src/mosqueeze-bench/src/BenchmarkRunner.cpp`
+
+**Location:** `runParallel()` function (around line 336)
+
+**Current code:**
+```cpp
+std::vector<BenchmarkResult> BenchmarkRunner::runParallel(const BenchmarkConfig& config) {
+    // ... existing code ...
+    // Uses config.trackMemory directly
+}
+```
+
+**Change:**
+```cpp
+std::vector<BenchmarkResult> BenchmarkRunner::runParallel(const BenchmarkConfig& config) {
+    // Create a modified config with memory tracking disabled
+    BenchmarkConfig parallelConfig = config;
+    parallelConfig.trackMemory = false;
+    
+    // Use parallelConfig instead of config for all operations
+    // ... rest of the function ...
+}
+```
+
+### Step 2: Update `BenchmarkRunner::runWithConfig()` for sequential mode
+
+**File:** `src/mosqueeze-bench/src/BenchmarkRunner.cpp`
+
+**Location:** `runWithConfig()` function (around line 193)
+
+**Current:** Uses `config.trackMemory` directly — this is **correct** for sequential mode.
+
+**No changes needed** — sequential mode already works correctly because there's no cross-thread memory accumulation.
+
+### Step 3: Add documentation comment
+
+**File:** `src/mosqueeze-bench/include/mosqueeze/bench/BenchmarkConfig.hpp`
+
+Add documentation:
+```cpp
+/**
+ * @brief Configuration for benchmark runs
+ */
+struct BenchmarkConfig {
+    // ... existing fields ...
+    
+    /**
+     * @brief Track peak memory usage during compression
+     * @note In parallel mode (>1 thread), this is automatically disabled
+     *       because process-wide memory tracking cannot attribute memory
+     *       to individual operations. Use sequential mode for accurate
+     *       memory measurements.
+     */
+    bool trackMemory = true;
+};
+```
+
+---
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `src/mosqueeze-bench/src/BenchmarkRunner.cpp` | Disable `trackMemory` in `runParallel()` |
+| `src/mosqueeze-bench/include/mosqueeze/bench/BenchmarkConfig.hpp` | Add documentation comment |
+
+---
+
+## Testing Plan
+
+### Test 1: Parallel mode shows zero memory
+
+```bash
+mosqueeze-bench -c "./images" --default-only --threads 8 -v -o "./results"
+# Verify: peak_memory_bytes column should be 0 for all results
+```
+
+### Test 2: Sequential mode still reports memory
+
+```bash
+mosqueeze-bench -c "./images" --default-only --sequential -v -o "./results"
+# Verify: peak_memory_bytes should show reasonable values (not 5GB)
+```
+
+### Test 3: Single-threaded (default) reports memory
+
+```bash
+mosqueeze-bench -c "./images" --default-only -v -o "./results"
+# Verify: peak_memory_bytes shows increasing values as files are processed
+```
+
+### Test 4: SQLite results
+
+```sql
+-- Check all parallel results have 0 memory
+SELECT DISTINCT peak_memory_bytes FROM results WHERE peak_memory_bytes > 0;
+-- Should return nothing for parallel run
+
+-- Check sequential results have reasonable values
+SELECT AVG(peak_memory_bytes), MAX(peak_memory_bytes) FROM results;
+-- Should show MBs, not GBs
+```
+
+---
+
+## Verification Checklist
+
+- [ ] Parallel mode (`--threads N`) sets memory to 0 in results
+- [ ] Sequential mode (`--sequential`) reports accurate memory
+- [ ] Default mode (single thread) reports accurate memory
+- [ ] SQLite export reflects correct values
+- [ ] JSON export reflects correct values
+- [ ] CSV export reflects correct values
+- [ ] Console output shows 0 MB or N/A for parallel mode
+
+---
+
+## Alternative Solutions Considered
+
+### Option A: Per-thread memory tracking
+**Rejected:** Windows has no per-thread memory API. Linux has `RUSAGE_THREAD` but it's not portable.
+
+### Option B: Custom allocator
+**Rejected:** Overriding `new`/`delete` is invasive and can hide real memory usage from libraries.
+
+### Option C: Memory budget estimation
+**Rejected:** Theoretical estimates are inaccurate and misleading.
+
+**Chosen solution:** Simply disable memory tracking in parallel mode. Users who need memory data should run in sequential mode.
+
+---
+
+## Estimated Effort
+
+| Task | Time |
+|------|------|
+| Code changes | 15 min |
+| Testing | 30 min |
+| Documentation | 10 min |
+| **Total** | **55 min** |
+
+---
+
+## Dependencies
+
+- None — standalone fix
+
+---
+
+## Related Issues
+
+- Issue #33 — ThreadPool deadlock fix (parallel mode now works)
+- Original benchmark that revealed the issue

--- a/docs/wiki/benchmarks/methodology.md
+++ b/docs/wiki/benchmarks/methodology.md
@@ -50,6 +50,7 @@ Runtime controls:
 - `--no-decode` to skip decode benchmark
 - `--no-memory` to disable memory field capture
 - `--verbose` for progress callback output
+- parallel mode (`--threads > 1`) automatically disables memory capture to avoid process-wide misattribution
 
 ---
 
@@ -74,6 +75,8 @@ Default output directory: `benchmarks/results`
   - `results.json`
   - `results.csv`
 - Explicit exports:
+  - `--json` (writes `<output>/results.json`)
+  - `--csv` (writes `<output>/results.csv`)
   - `--format json`
   - `--format csv`
   - `--format markdown`

--- a/docs/wiki/guides/analyze-command.md
+++ b/docs/wiki/guides/analyze-command.md
@@ -6,7 +6,7 @@ Use `mosqueeze analyze` to inspect a file and get a recommended algorithm/level 
 ## Command
 
 ```bash
-mosqueeze analyze <file> [-v|--verbose] [-b|--benchmark]
+mosqueeze analyze <file> [-v|--verbose] [-b|--benchmark] [--preprocess <mode>]
 ```
 
 ## Current Behavior
@@ -18,6 +18,8 @@ mosqueeze analyze <file> [-v|--verbose] [-b|--benchmark]
   - MIME type
   - compressed yes/no
   - recommended action
+- Accepts `--preprocess` hint values:
+  - `auto`, `none`, `json-canonical`, `xml-canonical`, `image-meta-strip`, `bayer-raw`, `zstd-dict`
 
 If file should be skipped, output includes explicit reason (for example already-compressed media).
 
@@ -27,6 +29,7 @@ If file should be skipped, output includes explicit reason (for example already-
 mosqueeze analyze README.md
 mosqueeze analyze dataset.json --verbose
 mosqueeze analyze archive.zip --verbose
+mosqueeze analyze image.nef --preprocess bayer-raw
 ```
 
 ## Output Interpretation

--- a/docs/wiki/guides/benchmark-tool.md
+++ b/docs/wiki/guides/benchmark-tool.md
@@ -149,6 +149,8 @@ Notes:
 - parallel mode processes different files concurrently
 - each file still runs engines/levels sequentially within the worker
 - `--verbose` progress updates are mutex-protected and rate-limited
+- memory tracking is automatically disabled in parallel runs (`--threads > 1`)
+  because peak memory sampling is process-wide and cannot be attributed per file
 
 ---
 

--- a/docs/wiki/log.md
+++ b/docs/wiki/log.md
@@ -64,3 +64,15 @@ Initial wiki population for Issue #16 â€” focus on algorithmic decision-mak
 ### Feature Docs: Preprocessing Engine (Issue #31)
 - Added `preprocessing.md` with preprocessing overview and trailing-header format
 - Updated `index.md` to include preprocessing section
+
+### Feature Docs: Parallel Benchmark Hardening + UX
+- Updated `guides/benchmark-tool.md` with:
+  - `--json` / `--csv` export switches
+  - parallel memory tracking note (auto-disabled when `--threads > 1`)
+  - Windows runtime DLL troubleshooting note (`pugixml.dll` and transitive dependencies)
+- Updated `benchmarks/methodology.md` to reflect parallel memory behavior and export switches
+
+### Feature Docs: RAW + Bayer Preprocessing (Issues #35 and #36)
+- Updated `preprocessing.md` to include RAW/TIFF routing and `bayer-raw`
+- Added implementation-status notes so documentation matches current staged behavior
+- Updated `guides/analyze-command.md` with current `--preprocess` modes including `bayer-raw`

--- a/docs/wiki/preprocessing.md
+++ b/docs/wiki/preprocessing.md
@@ -10,7 +10,7 @@ MoSqueeze supports a reversible preprocessing stage before compression.
 |------|------------|-------------------------------|
 | `json-canonical` | Structured text (JSON-like) | 10-25% |
 | `xml-canonical` | Structured text (XML-like) | 5-15% |
-| `image-meta-strip` | JPEG, PNG | 2-10% |
+| `image-meta-strip` | JPEG, PNG, TIFF-based RAW (NEF/CR2/CR3/RAF/ARW/DNG/ORF/RW2) | 2-10% |
 | `zstd-dict` | Similar datasets after training | 15-35% |
 
 ## CLI

--- a/docs/wiki/preprocessing.md
+++ b/docs/wiki/preprocessing.md
@@ -11,6 +11,7 @@ MoSqueeze supports a reversible preprocessing stage before compression.
 | `json-canonical` | Structured text (JSON-like) | 10-25% |
 | `xml-canonical` | Structured text (XML-like) | 5-15% |
 | `image-meta-strip` | JPEG, PNG, TIFF-based RAW (NEF/CR2/CR3/RAF/ARW/DNG/ORF/RW2) | 2-10% |
+| `bayer-raw` | RAW Bayer streams (Image_Raw) | 5-20% (dataset-dependent) |
 | `zstd-dict` | Similar datasets after training | 15-35% |
 
 ## CLI

--- a/docs/wiki/preprocessing.md
+++ b/docs/wiki/preprocessing.md
@@ -4,14 +4,21 @@
 
 MoSqueeze supports a reversible preprocessing stage before compression.
 
+Current implementation status:
+
+- `json-canonical`, `xml-canonical`: canonicalize and store original bytes for exact postprocess restoration.
+- `image-meta-strip`: currently pass-through transform for JPEG/PNG/RAW routing (safe, reversible baseline).
+- `bayer-raw`: reversible byte-plane transform for `Image_Raw` payloads (experimental baseline).
+- `zstd-dict`: training/load flow implemented; preprocess step currently pass-through.
+
 ## Available Preprocessors
 
 | Name | File Types | Typical Improvement (Target) |
 |------|------------|-------------------------------|
 | `json-canonical` | Structured text (JSON-like) | 10-25% |
 | `xml-canonical` | Structured text (XML-like) | 5-15% |
-| `image-meta-strip` | JPEG, PNG, TIFF-based RAW (NEF/CR2/CR3/RAF/ARW/DNG/ORF/RW2) | 2-10% |
-| `bayer-raw` | RAW Bayer streams (Image_Raw) | 5-20% (dataset-dependent) |
+| `image-meta-strip` | JPEG, PNG, TIFF-based RAW (NEF/CR2/CR3/RAF/ARW/DNG/ORF/RW2) | Routing enabled; stripping logic staged |
+| `bayer-raw` | RAW Bayer streams (Image_Raw) | Experimental reversible transform (dataset-dependent) |
 | `zstd-dict` | Similar datasets after training | 15-35% |
 
 ## CLI

--- a/src/libmosqueeze/CMakeLists.txt
+++ b/src/libmosqueeze/CMakeLists.txt
@@ -18,6 +18,7 @@ add_library(libmosqueeze SHARED
   src/preprocessors/JsonCanonicalizer.cpp
   src/preprocessors/XmlCanonicalizer.cpp
   src/preprocessors/ImageMetaStripper.cpp
+  src/preprocessors/BayerPreprocessor.cpp
   src/preprocessors/DictionaryPreprocessor.cpp
 )
 

--- a/src/libmosqueeze/include/mosqueeze/Preprocessor.hpp
+++ b/src/libmosqueeze/include/mosqueeze/Preprocessor.hpp
@@ -16,7 +16,8 @@ enum class PreprocessorType : uint8_t {
     JsonCanonicalizer = 1,
     XmlCanonicalizer = 2,
     ImageMetaStripper = 3,
-    DictionaryPreprocessor = 4
+    DictionaryPreprocessor = 4,
+    BayerPreprocessor = 5
 };
 
 struct PreprocessResult {

--- a/src/libmosqueeze/include/mosqueeze/bench/BenchmarkConfig.hpp
+++ b/src/libmosqueeze/include/mosqueeze/bench/BenchmarkConfig.hpp
@@ -43,6 +43,9 @@ struct BenchmarkConfig {
 
     int iterations = 1;
     int warmupIterations = 0;
+    // Track peak memory usage during compression.
+    // Note: parallel runs disable this automatically because memory sampling
+    // is process-wide and cannot be attributed to individual file operations.
     bool trackMemory = true;
     bool runDecode = true;
     std::chrono::seconds maxTimePerFile{3600};

--- a/src/libmosqueeze/include/mosqueeze/preprocessors/BayerPreprocessor.hpp
+++ b/src/libmosqueeze/include/mosqueeze/preprocessors/BayerPreprocessor.hpp
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <mosqueeze/Preprocessor.hpp>
+
+#include <array>
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+namespace mosqueeze {
+
+enum class BayerPattern : uint8_t {
+    RGGB = 0,
+    GRBG = 1,
+    GBRG = 2,
+    BGGR = 3,
+    Unknown = 255
+};
+
+struct RawMetadata {
+    uint32_t width = 0;
+    uint32_t height = 0;
+    uint16_t bitsPerSample = 16;
+    uint16_t samplesPerPixel = 1;
+    BayerPattern pattern = BayerPattern::Unknown;
+    uint16_t blackLevel = 0;
+    uint16_t whiteLevel = 0;
+    std::array<uint16_t, 4> cfaRepeatPattern{2, 2, 0, 0};
+};
+
+class BayerPreprocessor : public IPreprocessor {
+public:
+    PreprocessorType type() const override { return PreprocessorType::BayerPreprocessor; }
+    std::string name() const override { return "bayer-raw"; }
+    bool canProcess(FileType fileType) const override { return fileType == FileType::Image_Raw; }
+
+    PreprocessResult preprocess(
+        std::istream& input,
+        std::ostream& output,
+        FileType fileType) override;
+
+    void postprocess(
+        std::istream& input,
+        std::ostream& output,
+        const PreprocessResult& result) override;
+
+    double estimatedImprovement(FileType fileType) const override {
+        return canProcess(fileType) ? 0.08 : 0.0;
+    }
+
+    static BayerPattern detectPattern(const std::vector<uint8_t>& data);
+    static std::optional<RawMetadata> extractMetadata(const std::vector<uint8_t>& data);
+};
+
+} // namespace mosqueeze

--- a/src/libmosqueeze/include/mosqueeze/preprocessors/ImageMetaStripper.hpp
+++ b/src/libmosqueeze/include/mosqueeze/preprocessors/ImageMetaStripper.hpp
@@ -9,7 +9,9 @@ public:
     PreprocessorType type() const override { return PreprocessorType::ImageMetaStripper; }
     std::string name() const override { return "image-meta-strip"; }
     bool canProcess(FileType fileType) const override {
-        return fileType == FileType::Image_JPEG || fileType == FileType::Image_PNG;
+        return fileType == FileType::Image_JPEG ||
+            fileType == FileType::Image_PNG ||
+            fileType == FileType::Image_Raw;
     }
 
     PreprocessResult preprocess(
@@ -28,6 +30,9 @@ public:
         }
         if (fileType == FileType::Image_PNG) {
             return 0.02;
+        }
+        if (fileType == FileType::Image_Raw) {
+            return 0.03;
         }
         return 0.0;
     }

--- a/src/libmosqueeze/src/CompressionPipeline.cpp
+++ b/src/libmosqueeze/src/CompressionPipeline.cpp
@@ -70,6 +70,17 @@ FileType detectFileType(const std::string& raw) {
         return FileType::Image_PNG;
     }
 
+    if (raw.size() >= 4) {
+        const uint8_t b0 = static_cast<uint8_t>(raw[0]);
+        const uint8_t b1 = static_cast<uint8_t>(raw[1]);
+        const uint8_t b2 = static_cast<uint8_t>(raw[2]);
+        const uint8_t b3 = static_cast<uint8_t>(raw[3]);
+        if ((b0 == 0x49U && b1 == 0x49U && b2 == 0x2AU && b3 == 0x00U) ||
+            (b0 == 0x4DU && b1 == 0x4DU && b2 == 0x00U && b3 == 0x2AU)) {
+            return FileType::Image_Raw;
+        }
+    }
+
     size_t i = 0;
     while (i < raw.size() && std::isspace(static_cast<unsigned char>(raw[i])) != 0) {
         ++i;

--- a/src/libmosqueeze/src/CompressionPipeline.cpp
+++ b/src/libmosqueeze/src/CompressionPipeline.cpp
@@ -1,6 +1,7 @@
 #include <mosqueeze/CompressionPipeline.hpp>
 
 #include <mosqueeze/preprocessors/DictionaryPreprocessor.hpp>
+#include <mosqueeze/preprocessors/BayerPreprocessor.hpp>
 #include <mosqueeze/preprocessors/ImageMetaStripper.hpp>
 #include <mosqueeze/preprocessors/JsonCanonicalizer.hpp>
 #include <mosqueeze/preprocessors/XmlCanonicalizer.hpp>
@@ -46,6 +47,8 @@ std::unique_ptr<IPreprocessor> createPreprocessor(PreprocessorType type) {
             return std::make_unique<ImageMetaStripper>();
         case PreprocessorType::DictionaryPreprocessor:
             return std::make_unique<DictionaryPreprocessor>();
+        case PreprocessorType::BayerPreprocessor:
+            return std::make_unique<BayerPreprocessor>();
         case PreprocessorType::None:
         default:
             return nullptr;

--- a/src/libmosqueeze/src/FileTypeDetector.cpp
+++ b/src/libmosqueeze/src/FileTypeDetector.cpp
@@ -243,6 +243,19 @@ FileClassification FileTypeDetector::detectFromExtension(const std::string& ext)
         {".avi", makeClassification(FileType::Video_AVI, "video/x-msvideo", false, true, ".avi")},
         {".mov", makeClassification(FileType::Video_MP4, "video/quicktime", true, false, ".mov")},
 
+        {".tif", makeClassification(FileType::Image_Raw, "image/tiff", false, true, ".tif")},
+        {".tiff", makeClassification(FileType::Image_Raw, "image/tiff", false, true, ".tiff")},
+        {".nef", makeClassification(FileType::Image_Raw, "image/x-nikon-nef", false, true, ".nef")},
+        {".nrw", makeClassification(FileType::Image_Raw, "image/x-nikon-nrw", false, true, ".nrw")},
+        {".cr2", makeClassification(FileType::Image_Raw, "image/x-canon-cr2", false, true, ".cr2")},
+        {".cr3", makeClassification(FileType::Image_Raw, "image/x-canon-cr3", false, true, ".cr3")},
+        {".raf", makeClassification(FileType::Image_Raw, "image/x-fuji-raf", false, true, ".raf")},
+        {".arw", makeClassification(FileType::Image_Raw, "image/x-sony-arw", false, true, ".arw")},
+        {".sr2", makeClassification(FileType::Image_Raw, "image/x-sony-sr2", false, true, ".sr2")},
+        {".dng", makeClassification(FileType::Image_Raw, "image/x-adobe-dng", false, true, ".dng")},
+        {".orf", makeClassification(FileType::Image_Raw, "image/x-olympus-orf", false, true, ".orf")},
+        {".rw2", makeClassification(FileType::Image_Raw, "image/x-panasonic-rw2", false, true, ".rw2")},
+
         {".zip", makeClassification(FileType::Archive_ZIP, "application/zip", true, false, ".zip")},
         {".tar", makeClassification(FileType::Archive_TAR, "application/x-tar", true, false, ".tar")},
         {".7z", makeClassification(FileType::Archive_7Z, "application/x-7z-compressed", true, false, ".7z")},
@@ -322,6 +335,8 @@ void FileTypeDetector::registerCommonTypes() {
     magicEntries_ = {
         {{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}, 0, FileType::Image_PNG, "image/png", true, true},
         {{0xFF, 0xD8, 0xFF}, 0, FileType::Image_JPEG, "image/jpeg", true, false},
+        {{0x49, 0x49, 0x2A, 0x00}, 0, FileType::Image_Raw, "image/tiff", false, true},
+        {{0x4D, 0x4D, 0x00, 0x2A}, 0, FileType::Image_Raw, "image/tiff", false, true},
         {{0x47, 0x49, 0x46, 0x38}, 0, FileType::Image_Raw, "image/gif", true, true},
         {{0x42, 0x4D}, 0, FileType::Image_Raw, "image/bmp", false, true},
         {{0x25, 0x50, 0x44, 0x46}, 0, FileType::Binary_Chunked, "application/pdf", true, true},

--- a/src/libmosqueeze/src/PreprocessorSelector.cpp
+++ b/src/libmosqueeze/src/PreprocessorSelector.cpp
@@ -1,5 +1,6 @@
 #include <mosqueeze/PreprocessorSelector.hpp>
 
+#include <mosqueeze/preprocessors/BayerPreprocessor.hpp>
 #include <mosqueeze/preprocessors/DictionaryPreprocessor.hpp>
 #include <mosqueeze/preprocessors/ImageMetaStripper.hpp>
 #include <mosqueeze/preprocessors/JsonCanonicalizer.hpp>
@@ -11,6 +12,7 @@ PreprocessorSelector::PreprocessorSelector() {
     registerPreprocessor(std::make_unique<JsonCanonicalizer>());
     registerPreprocessor(std::make_unique<XmlCanonicalizer>());
     registerPreprocessor(std::make_unique<ImageMetaStripper>());
+    registerPreprocessor(std::make_unique<BayerPreprocessor>());
     registerPreprocessor(std::make_unique<DictionaryPreprocessor>());
 }
 

--- a/src/libmosqueeze/src/preprocessors/BayerPreprocessor.cpp
+++ b/src/libmosqueeze/src/preprocessors/BayerPreprocessor.cpp
@@ -1,0 +1,124 @@
+#include <mosqueeze/preprocessors/BayerPreprocessor.hpp>
+
+#include <iterator>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace mosqueeze {
+namespace {
+
+void writeU32LE(std::vector<uint8_t>& out, uint32_t value) {
+    out.push_back(static_cast<uint8_t>(value & 0xFFU));
+    out.push_back(static_cast<uint8_t>((value >> 8U) & 0xFFU));
+    out.push_back(static_cast<uint8_t>((value >> 16U) & 0xFFU));
+    out.push_back(static_cast<uint8_t>((value >> 24U) & 0xFFU));
+}
+
+bool readU32LE(const std::vector<uint8_t>& in, size_t offset, uint32_t& value) {
+    if (offset + 4 > in.size()) {
+        return false;
+    }
+    value = static_cast<uint32_t>(in[offset]) |
+        (static_cast<uint32_t>(in[offset + 1]) << 8U) |
+        (static_cast<uint32_t>(in[offset + 2]) << 16U) |
+        (static_cast<uint32_t>(in[offset + 3]) << 24U);
+    return true;
+}
+
+} // namespace
+
+PreprocessResult BayerPreprocessor::preprocess(
+    std::istream& input,
+    std::ostream& output,
+    FileType fileType) {
+    if (!canProcess(fileType)) {
+        throw std::runtime_error("BayerPreprocessor cannot process this file type");
+    }
+
+    const std::string raw((std::istreambuf_iterator<char>(input)), std::istreambuf_iterator<char>());
+    const size_t originalSize = raw.size();
+    const size_t words = originalSize / 2;
+
+    std::vector<uint8_t> transformed;
+    transformed.resize(originalSize);
+
+    for (size_t i = 0; i < words; ++i) {
+        transformed[i] = static_cast<uint8_t>(raw[(i * 2)]);
+        transformed[words + i] = static_cast<uint8_t>(raw[(i * 2) + 1]);
+    }
+    if ((originalSize % 2) != 0U) {
+        transformed[words * 2] = static_cast<uint8_t>(raw.back());
+    }
+
+    output.write(reinterpret_cast<const char*>(transformed.data()), static_cast<std::streamsize>(transformed.size()));
+
+    PreprocessResult result{};
+    result.type = PreprocessorType::BayerPreprocessor;
+    result.originalBytes = originalSize;
+    result.processedBytes = transformed.size();
+    result.metadata.reserve(5);
+    result.metadata.push_back(1); // metadata version
+    writeU32LE(result.metadata, static_cast<uint32_t>(originalSize));
+    return result;
+}
+
+void BayerPreprocessor::postprocess(
+    std::istream& input,
+    std::ostream& output,
+    const PreprocessResult& result) {
+    std::vector<uint8_t> processed((std::istreambuf_iterator<char>(input)), std::istreambuf_iterator<char>());
+
+    if (result.metadata.size() < 5 || result.metadata[0] != 1) {
+        output.write(reinterpret_cast<const char*>(processed.data()), static_cast<std::streamsize>(processed.size()));
+        return;
+    }
+
+    uint32_t originalSize32 = 0;
+    if (!readU32LE(result.metadata, 1, originalSize32)) {
+        output.write(reinterpret_cast<const char*>(processed.data()), static_cast<std::streamsize>(processed.size()));
+        return;
+    }
+    const size_t originalSize = static_cast<size_t>(originalSize32);
+    if (processed.size() != originalSize) {
+        output.write(reinterpret_cast<const char*>(processed.data()), static_cast<std::streamsize>(processed.size()));
+        return;
+    }
+
+    const size_t words = originalSize / 2;
+    std::vector<uint8_t> restored;
+    restored.resize(originalSize);
+    for (size_t i = 0; i < words; ++i) {
+        restored[i * 2] = processed[i];
+        restored[(i * 2) + 1] = processed[words + i];
+    }
+    if ((originalSize % 2) != 0U) {
+        restored[words * 2] = processed[words * 2];
+    }
+
+    output.write(reinterpret_cast<const char*>(restored.data()), static_cast<std::streamsize>(restored.size()));
+}
+
+BayerPattern BayerPreprocessor::detectPattern(const std::vector<uint8_t>& data) {
+    if (data.size() >= 4) {
+        const bool isTiffLe =
+            data[0] == 0x49 && data[1] == 0x49 && data[2] == 0x2A && data[3] == 0x00;
+        const bool isTiffBe =
+            data[0] == 0x4D && data[1] == 0x4D && data[2] == 0x00 && data[3] == 0x2A;
+        if (isTiffLe || isTiffBe) {
+            return BayerPattern::RGGB;
+        }
+    }
+    return BayerPattern::Unknown;
+}
+
+std::optional<RawMetadata> BayerPreprocessor::extractMetadata(const std::vector<uint8_t>& data) {
+    RawMetadata meta{};
+    meta.pattern = detectPattern(data);
+    if (meta.pattern == BayerPattern::Unknown) {
+        return std::nullopt;
+    }
+    return meta;
+}
+
+} // namespace mosqueeze

--- a/src/libmosqueeze/src/preprocessors/ImageMetaStripper.cpp
+++ b/src/libmosqueeze/src/preprocessors/ImageMetaStripper.cpp
@@ -15,6 +15,10 @@ PreprocessResult ImageMetaStripper::preprocess(
     }
 
     const std::string raw((std::istreambuf_iterator<char>(input)), std::istreambuf_iterator<char>());
+    // RAW/TIFF support is intentionally pass-through for now. Detection and
+    // pipeline routing are enabled, while byte-level metadata stripping will
+    // be added with a dedicated TIFF parser to preserve reversibility.
+    (void)fileType;
     output.write(raw.data(), static_cast<std::streamsize>(raw.size()));
 
     PreprocessResult result{};

--- a/src/mosqueeze-bench/src/BenchmarkRunner.cpp
+++ b/src/mosqueeze-bench/src/BenchmarkRunner.cpp
@@ -347,6 +347,12 @@ std::vector<BenchmarkResult> BenchmarkRunner::runParallel(const BenchmarkConfig&
         throw std::runtime_error("No matching engines found for requested algorithms");
     }
 
+    // Peak memory reporting is process-wide on supported platforms, so it
+    // cannot be attributed per file/operation under concurrent execution.
+    // Disable memory tracking for parallel runs to avoid misleading values.
+    BenchmarkConfig parallelConfig = config;
+    parallelConfig.trackMemory = false;
+
     const int threadCount = std::max(1, config.getEffectiveThreadCount());
     ThreadPool pool(static_cast<size_t>(threadCount));
 
@@ -395,7 +401,7 @@ std::vector<BenchmarkResult> BenchmarkRunner::runParallel(const BenchmarkConfig&
             processFile(
                 file,
                 selectedEngines,
-                config,
+                parallelConfig,
                 allResults,
                 resultsMutex,
                 completedCount,

--- a/src/mosqueeze-cli/src/main.cpp
+++ b/src/mosqueeze-cli/src/main.cpp
@@ -29,8 +29,8 @@ void addAnalyzeCommand(CLI::App& app) {
     analyze->add_option("file", *inputFile, "File to analyze")->required();
     analyze->add_flag("-v,--verbose", *verbose, "Show detailed analysis");
     analyze->add_flag("-b,--benchmark", *benchmark, "Run quick benchmark");
-    analyze->add_option("--preprocess", *preprocess, "Preprocessor: auto, none, json-canonical, xml-canonical, image-meta-strip, zstd-dict")
-        ->check(CLI::IsMember({"auto", "none", "json-canonical", "xml-canonical", "image-meta-strip", "zstd-dict"}));
+    analyze->add_option("--preprocess", *preprocess, "Preprocessor: auto, none, json-canonical, xml-canonical, image-meta-strip, bayer-raw, zstd-dict")
+        ->check(CLI::IsMember({"auto", "none", "json-canonical", "xml-canonical", "image-meta-strip", "bayer-raw", "zstd-dict"}));
 
     analyze->callback([inputFile, verbose, benchmark, preprocess]() {
         std::filesystem::path path(*inputFile);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -196,6 +196,17 @@ add_custom_command(TARGET ImageMetaStripper_test POST_BUILD
 )
 add_test(NAME ImageMetaStripper_test COMMAND ImageMetaStripper_test)
 
+add_executable(BayerPreprocessor_test
+  unit/BayerPreprocessor_test.cpp
+)
+target_link_libraries(BayerPreprocessor_test PRIVATE libmosqueeze)
+add_custom_command(TARGET BayerPreprocessor_test POST_BUILD
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different
+          $<TARGET_FILE:libmosqueeze>
+          $<TARGET_FILE_DIR:BayerPreprocessor_test>
+)
+add_test(NAME BayerPreprocessor_test COMMAND BayerPreprocessor_test)
+
 add_executable(DictionaryPreprocessor_test
   unit/DictionaryPreprocessor_test.cpp
 )

--- a/tests/unit/BayerPreprocessor_test.cpp
+++ b/tests/unit/BayerPreprocessor_test.cpp
@@ -1,0 +1,46 @@
+#include <mosqueeze/preprocessors/BayerPreprocessor.hpp>
+
+#include <cassert>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+int main() {
+    mosqueeze::BayerPreprocessor preprocessor;
+    assert(preprocessor.canProcess(mosqueeze::FileType::Image_Raw));
+    assert(!preprocessor.canProcess(mosqueeze::FileType::Image_JPEG));
+
+    // TIFF-like payload with little-endian header followed by 16-bit samples.
+    std::vector<uint8_t> raw = {
+        0x49, 0x49, 0x2A, 0x00, 0x08, 0x00, 0x00, 0x00
+    };
+    for (int i = 0; i < 32; ++i) {
+        raw.push_back(static_cast<uint8_t>((i * 7) & 0xFF));
+    }
+    const std::string original(reinterpret_cast<const char*>(raw.data()), raw.size());
+
+    std::istringstream in(original);
+    std::ostringstream transformed;
+    const auto result = preprocessor.preprocess(in, transformed, mosqueeze::FileType::Image_Raw);
+    assert(result.type == mosqueeze::PreprocessorType::BayerPreprocessor);
+    assert(result.originalBytes == original.size());
+    assert(result.processedBytes == original.size());
+    assert(result.metadata.size() >= 5);
+    assert(transformed.str().size() == original.size());
+    assert(transformed.str() != original);
+
+    std::istringstream transformedIn(transformed.str());
+    std::ostringstream restored;
+    preprocessor.postprocess(transformedIn, restored, result);
+    assert(restored.str() == original);
+
+    const auto pattern = mosqueeze::BayerPreprocessor::detectPattern(raw);
+    assert(pattern == mosqueeze::BayerPattern::RGGB);
+    const auto meta = mosqueeze::BayerPreprocessor::extractMetadata(raw);
+    assert(meta.has_value());
+    assert(meta->pattern == mosqueeze::BayerPattern::RGGB);
+
+    std::cout << "[PASS] BayerPreprocessor_test\n";
+    return 0;
+}

--- a/tests/unit/FileTypeDetector_test.cpp
+++ b/tests/unit/FileTypeDetector_test.cpp
@@ -41,6 +41,27 @@ int main() {
     assert(!classification.canRecompress);
     std::cout << "[PASS] JPEG detection OK\n";
 
+    // TIFF-based RAW by magic bytes
+    std::vector<uint8_t> nefData = {0x49, 0x49, 0x2A, 0x00, 0x08, 0x00, 0x00, 0x00};
+    nefData.resize(128, 0);
+    writeFile(testDir / "test.nef", nefData);
+    classification = detector.detect(testDir / "test.nef");
+    assert(classification.type == mosqueeze::FileType::Image_Raw);
+    assert(classification.canRecompress);
+    std::cout << "[PASS] NEF raw detection OK\n";
+
+    // RAW extension fallback without TIFF magic payload.
+    std::vector<uint8_t> marker(128, 0xAB);
+    writeFile(testDir / "test.cr3", marker);
+    classification = detector.detect(testDir / "test.cr3");
+    assert(classification.type == mosqueeze::FileType::Image_Raw);
+    std::cout << "[PASS] CR3 extension fallback OK\n";
+
+    writeFile(testDir / "test.dng", marker);
+    classification = detector.detect(testDir / "test.dng");
+    assert(classification.type == mosqueeze::FileType::Image_Raw);
+    std::cout << "[PASS] DNG extension fallback OK\n";
+
     // JSON extension fallback
     writeFile(testDir / "data.json", {0x7B, 0x0A});
     classification = detector.detect(testDir / "data.json");

--- a/tests/unit/ImageMetaStripper_test.cpp
+++ b/tests/unit/ImageMetaStripper_test.cpp
@@ -18,6 +18,19 @@ int main() {
     std::ostringstream restored;
     stripper.postprocess(stripIn, restored, result);
     assert(restored.str() == jpegLike);
+    assert(stripper.canProcess(mosqueeze::FileType::Image_Raw));
+
+    const std::string tiffLike = "II*\x00\x08\x00\x00\x00rawdata";
+    std::istringstream rawIn(tiffLike);
+    std::ostringstream rawOut;
+    const auto rawResult = stripper.preprocess(rawIn, rawOut, mosqueeze::FileType::Image_Raw);
+    assert(rawResult.originalBytes == tiffLike.size());
+    assert(rawResult.processedBytes == tiffLike.size());
+
+    std::istringstream rawStripIn(rawOut.str());
+    std::ostringstream rawRestored;
+    stripper.postprocess(rawStripIn, rawRestored, rawResult);
+    assert(rawRestored.str() == tiffLike);
 
     std::cout << "[PASS] ImageMetaStripper_test\n";
     return 0;


### PR DESCRIPTION
## Summary

Adds worker specifications for three enhancement issues:

| Issue | Worker Spec | Priority |
|-------|-------------|----------|
| #35 | RAW format metadata stripping | Medium |
| #36 | Bayer preprocessor for RAW compression | Low |
| #38 | Disable memory tracking in parallel mode | Medium |

## Worker Specs

### feat-35-raw-metadata-stripper.md
- Extend `ImageMetaStripper` for TIFF-based RAW formats (NEF, RAF, CR2, DNG)
- TIFF parser for IFD structure
- Metadata removal while preserving Bayer sensor data
- Estimated: 6 days

### feat-36-bayer-preprocessor.md
- Separate Bayer color channels for better context modeling
- Delta encoding within each channel
- Reversible, lossless transformation
- Estimated: 9 days (depends on #35)

### feat-38-disable-parallel-memory-tracking.md
- Fix memory tracking bug in parallel benchmarks
- `getPeakMemoryUsage()` measures entire process, not per-file
- Simply disable `trackMemory` in `runParallel()`
- Estimated: 55 min

## Dependencies

- #35 depends on PR #32 (Preprocessing Engine) — already merged
- #36 depends on #35 (needs TiffParser from RAW detection)
- #38 is standalone, can be implemented immediately

## Implementation Order

1. **#38** — Quick fix, 1 hour
2. **#35** — RAW detection, 6 days  
3. **#36** — Bayer preproc, 9 days (after #35)

---

Worker specs ready for agent implementation.