### PR TITLE
Add preprocessor test coverage and selector checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ mosqueeze v0.1.0
 ```bash
 cd build
 ctest --output-on-failure
+
+# Run only preprocessor-focused tests
+ctest -R "BayerPreprocessor_test|ImageMetaStripper_test|JsonCanonicalizer_test|XmlCanonicalizer_test|DictionaryPreprocessor_test|PreprocessorSelector_test" --output-on-failure
 ```
 
 ## Documentation

--- a/docs/features/feat-52-preprocessor-tests.md
+++ b/docs/features/feat-52-preprocessor-tests.md
@@ -1,0 +1,404 @@
+# Worker Spec: Preprocessor Unit Test Suite
+
+**Issue:** #52 - Feature: Preprocessor Unit Test Suite  
+**Branch:** `feat/preprocessor-tests`  
+**Priority:** Medium  
+**Estimated Effort:** 1-2 days  
+
+---
+
+## Overview
+
+Create comprehensive unit tests for all preprocessors to prevent regressions and validate correctness. This addresses the BayerPreprocessor bug (#46) where the entire RAF file was processed instead of just image data - unit tests would have caught this.
+
+---
+
+## Goals
+
+1. **Correctness validation** - Ensure round-trip integrity for all preprocessors
+2. **Edge case handling** - Test malformed input, empty files, large files
+3. **Performance benchmarks** - Establish baseline performance metrics
+4. **CI integration** - Add to build pipeline with coverage reporting
+
+---
+
+## Test Categories
+
+### 1. Correctness Tests (Round-trip)
+
+Each preprocessor must ensure data integrity:
+
+```cpp
+// For lossless preprocessors (BayerPreprocessor, PngOptimizer, ImageMetaStripper)
+TEST_CASE("BayerPreprocessor round-trip") {
+    auto original = loadRafFile("test.raf");
+    auto processed = BayerPreprocessor::process(original);
+    auto decompressed = decompress(compress(processed));
+    auto restored = BayerPreprocessor::restore(decompressed);
+    REQUIRE(original == restored);  // Pixel-perfect
+}
+
+// For canonicalizers (JsonCanonicalizer, XmlCanonicalizer)
+TEST_CASE("JsonCanonicalizer semantic equivalence") {
+    auto json1 = R"({"b":2,"a":1})"_json;
+    auto json2 = R"({"a":1,"b":2})"_json;
+    auto canonical = JsonCanonicalizer::process(json1);
+    REQUIRE(canonical == JsonCanonicalizer::process(json2));
+    REQUIRE(parse(canonical) == json1);  // Semantic equivalence
+}
+```
+
+### 2. Edge Cases
+
+```cpp
+TEST_CASE("Empty file handling") {
+    REQUIRE_NOTHROW(BayerPreprocessor::process(std::vector<uint8_t>{}));
+    REQUIRE_NOTHROW(PngOptimizer::process(std::vector<uint8_t>{}));
+}
+
+TEST_CASE("Malformed input") {
+    auto garbage = generateRandomBytes(1024);
+    REQUIRE_THROWS_AS(PngOptimizer::process(garbage), InvalidFormatError);
+    REQUIRE_NOTHROW(ImageMetaStripper::process(garbage));  // Best-effort stripping
+}
+
+TEST_CASE("Large file (>1GB)") {
+    // Test with streaming mock or subset
+    auto large = generateLargeRaf(1.5 * 1024 * 1024 * 1024);
+    REQUIRE_NOTHROW(BayerPreprocessor::process(large));
+}
+
+TEST_CASE("Already optimally compressed") {
+    auto optimized7z = loadFile("optimized.7z");
+    auto processed = PreprocessorChain::process(optimized7z);
+    REQUIRE(processed.size() >= optimized7z.size());  // No improvement
+}
+```
+
+### 3. Format-Specific Tests
+
+#### BayerPreprocessor
+```cpp
+TEST_CASE("BayerPreprocessor: RAF format detection")
+TEST_CASE("BayerPreprocessor: Header preservation")
+TEST_CASE("BayerPreprocessor: Only image data processed")
+TEST_CASE("BayerPreprocessor: Lossless-compressed skip")
+TEST_CASE("BayerPreprocessor: All Bayer patterns (RGGB, BGGR, GRBG, GBRG)")
+```
+
+#### PngOptimizer
+```cpp
+TEST_CASE("PngOptimizer: Filter selection (0-4)")
+TEST_CASE("PngOptimizer: Metadata stripping")
+TEST_CASE("PngOptimizer: Compression level comparison")
+TEST_CASE("PngOptimizer: Palette optimization")
+TEST_CASE("PngOptimizer: Interlaced PNG handling")
+```
+
+#### ImageMetaStripper
+```cpp
+TEST_CASE("ImageMetaStripper: JPEG EXIF removal")
+TEST_CASE("ImageMetaStripper: PNG XMP removal")
+TEST_CASE("ImageMetaStripper: WebP ICC profile removal")
+TEST_CASE("ImageMetaStripper: Preserve image data")
+```
+
+#### JsonCanonicalizer
+```cpp
+TEST_CASE("JsonCanonicalizer: Key ordering")
+TEST_CASE("JsonCanonicalizer: Whitespace normalization")
+TEST_CASE("JsonCanonicalizer: Unicode handling")
+TEST_CASE("JsonCanonicalizer: Nested objects")
+TEST_CASE("JsonCanonicalizer: Arrays preserved")
+```
+
+#### XmlCanonicalizer
+```cpp
+TEST_CASE("XmlCanonicalizer: Attribute ordering")
+TEST_CASE("XmlCanonicalizer: Namespace handling")
+TEST_CASE("XmlCanonicalizer: Whitespace normalization")
+TEST_CASE("XmlCanonicalizer: CDATA sections")
+```
+
+---
+
+## Proposed Test Suite Structure
+
+```
+tests/
+├── CMakeLists.txt
+├── test_main.cpp
+├── preprocessors/
+│   ├── BayerPreprocessor_test.cpp
+│   ├── PngOptimizer_test.cpp
+│   ├── ImageMetaStripper_test.cpp
+│   ├── JsonCanonicalizer_test.cpp
+│   ├── XmlCanonicalizer_test.cpp
+│   └── PreprocessorChain_test.cpp
+├── fixtures/
+│   ├── images/
+│   │   ├── sample.raf          # Fujifilm RAW
+│   │   ├── sample.png          # Test PNG with metadata
+│   │   ├── sample.jpg          # Test JPEG with EXIF
+│   │   └── sample.webp         # Test WebP
+│   ├── data/
+│   │   ├── sample.json         # Test JSON
+│   │   ├── sample.xml          # Test XML
+│   │   └── malformed.*         # Malformed test cases
+│   └── edge_cases/
+│       ├── empty.bin
+│       ├── tiny.bin            # 1 byte
+│       └── large.bin           # 10MB+
+└── integration/
+    ├── round_trip_test.cpp
+    └── compression_pipeline_test.cpp
+```
+
+---
+
+## Test Fixtures
+
+### Required Test Files
+
+1. **sample.raf** - Fujifilm RAW (can use existing benchmark files)
+2. **sample.png** - PNG with EXIF, XMP, ICC profile
+3. **sample.jpg** - JPEG with full EXIF
+4. **sample.json** - JSON with nested objects, arrays, unicode
+5. **sample.xml** - XML with namespaces, attributes
+6. **malformed.*** - Edge case files for error handling
+
+### Fixture Generation
+
+```cpp
+// Generate test fixtures if not present
+void ensureTestFixtures() {
+    if (!fs::exists("fixtures/images/sample.png")) {
+        generateTestPng("fixtures/images/sample.png", 100, 100, {
+            .withExif = true,
+            .withXmp = true,
+            .withIcc = true
+        });
+    }
+    // Similar for other formats
+}
+```
+
+---
+
+## Performance Tests
+
+```cpp
+class PreprocessorBenchmark : public Catch::BenchmarkListener {
+    TEST_CASE("BayerPreprocessor performance", "[!benchmark]") {
+        auto file = loadRafFile("large.raf");
+        BENCHMARK("Process 50MB RAF") {
+            return BayerPreprocessor::process(file);
+        };
+    }
+    
+    TEST_CASE("PngOptimizer performance", "[!benchmark]") {
+        auto png = loadPngFile("large.png");
+        BENCHMARK("Optimize 10MB PNG") {
+            return PngOptimizer::process(png);
+        };
+    }
+};
+```
+
+### Performance Baselines
+
+| Preprocessor | File Size | Target Time |
+|--------------|-----------|-------------|
+| BayerPreprocessor | 50MB RAF | <500ms |
+| PngOptimizer | 10MB PNG | <1s (level 9) |
+| JsonCanonicalizer | 1MB JSON | <50ms |
+| XmlCanonicalizer | 1MB XML | <50ms |
+| ImageMetaStripper | 5MB JPEG | <100ms |
+
+---
+
+## CI Integration
+
+### CMakeLists.txt Additions
+
+```cmake
+# Test configuration
+enable_testing()
+
+# Catch2 setup
+include(FetchContent)
+FetchContent_Declare(
+    Catch2
+    GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+    GIT_TAG v3.5.0
+)
+FetchContent_MakeAvailable(Catch2)
+
+# Test executable
+add_executable(mosqueeze_tests
+    tests/test_main.cpp
+    tests/preprocessors/BayerPreprocessor_test.cpp
+    tests/preprocessors/PngOptimizer_test.cpp
+    tests/preprocessors/ImageMetaStripper_test.cpp
+    tests/preprocessors/JsonCanonicalizer_test.cpp
+    tests/preprocessors/XmlCanonicalizer_test.cpp
+)
+
+target_link_libraries(mosqueeze_tests PRIVATE
+    mosqueeze_lib
+    Catch2::Catch2WithMain
+)
+
+# Register tests
+include(Catch)
+catch_discover_tests(mosqueeze_tests)
+```
+
+### GitHub Actions Workflow Addition
+
+```yaml
+# Add to existing CI workflow
+- name: Run Tests
+  run: |
+    cmake --build build --config Release
+    ctest --test-dir build --output-on-failure
+  
+- name: Coverage Report
+  if: matrix.os == 'ubuntu-latest'
+  run: |
+    cmake -B build -DCMAKE_BUILD_TYPE=Debug -DENABLE_COVERAGE=ON
+    cmake --build build
+    ctest --test-dir build
+    bash <(curl -s https://codecov.io/bash)
+```
+
+---
+
+## Memory Tests
+
+Valgrind / AddressSanitizer integration:
+
+```cmake
+option(ENABLE_ASAN "Enable AddressSanitizer" OFF)
+if(ENABLE_ASAN)
+    target_compile_options(mosqueeze_tests PRIVATE -fsanitize=address -fno-omit-frame-pointer)
+    target_link_options(mosqueeze_tests PRIVATE -fsanitize=address)
+endif()
+```
+
+---
+
+## Implementation Steps
+
+### Phase 1: Setup (2-3 hours)
+1. [ ] Add Catch2 dependency via FetchContent
+2. [ ] Create test directory structure
+3. [ ] Set up test main and CMake integration
+4. [ ] Add `ctest` to CI workflow
+
+### Phase 2: Test Fixtures (1-2 hours)
+1. [ ] Add minimal test fixtures (empty files, valid samples)
+2. [ ] Generate malformed test files
+3. [ ] Add fixture generation utilities
+
+### Phase 3: Correctness Tests (4-6 hours)
+1. [ ] BayerPreprocessor correctness tests
+2. [ ] PngOptimizer correctness tests
+3. [ ] ImageMetaStripper correctness tests
+4. [ ] JsonCanonicalizer correctness tests
+5. [ ] XmlCanonicalizer correctness tests
+
+### Phase 4: Edge Cases (2-3 hours)
+1. [ ] Empty file tests
+2. [ ] Malformed input tests
+3. [ ] Large file tests (streaming)
+4. [ ] Already-optimized tests
+
+### Phase 5: Performance (1-2 hours)
+1. [ ] Add benchmark macros
+2. [ ] Establish baseline measurements
+3. [ ] Add performance regression tests
+
+### Phase 6: CI Integration (1 hour)
+1. [ ] Add coverage reporting
+2. [ ] Add ASAN builds
+3. [ ] Update README with test commands
+
+---
+
+## Test Commands
+
+```bash
+# Build tests
+cmake -B build -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=ON
+cmake --build build
+
+# Run all tests
+ctest --test-dir build --output-on-failure
+
+# Run specific test suite
+./build/tests/mosqueeze_tests "[BayerPreprocessor]"
+
+# Run with verbose output
+./build/tests/mosqueeze_tests -s
+
+# Run benchmarks
+./build/tests/mosqueeze_tests "[!benchmark]"
+
+# Coverage
+cmake -B build -DCMAKE_BUILD_TYPE=Debug -DENABLE_COVERAGE=ON
+cmake --build build
+ctest --test-dir build
+gcovr -r . build
+```
+
+---
+
+## Acceptance Criteria
+
+- [ ] Unit tests for all 5 preprocessors
+- [ ] Round-trip correctness verified for lossless preprocessors
+- [ ] Semantic equivalence verified for canonicalizers
+- [ ] Edge case handling (empty, malformed, large)
+- [ ] Performance baselines established
+- [ ] CI integration with coverage reporting
+- [ ] Test fixtures for common file formats
+- [ ] README updated with test commands
+- [ ] All tests passing on CI (Linux, macOS, Windows)
+
+---
+
+## Related Issues
+
+- #46: BayerPreprocessor RAF parsing bug (would have been caught)
+- #13: PNG optimization (tests needed)
+- #51: oxipng integration (tests needed)
+
+---
+
+## Testing Philosophy
+
+> "Tests don't prove code works; they prove code doesn't break in tested ways."
+
+This test suite focuses on:
+1. **Regression prevention** - If BayerPreprocessor breaks again, tests catch it
+2. **Documentation** - Tests show how preprocessors should behave
+3. **Confidence** - Refactor safely with test coverage
+4. **Performance tracking** - Catch performance regressions early
+
+---
+
+## Dependencies
+
+- **Catch2 v3.x** - Test framework (header-only option available)
+- **CTest** - CMake test runner (built-in)
+- **gcov/codecov** - Coverage reporting (optional)
+
+---
+
+## Notes
+
+- This is a foundational improvement that all future preprocessor work benefits from
+- Tests should be co-located with implementation in `tests/preprocessors/`
+- Use `TEST_CASE_METHOD` for shared fixture setup
+- Mark slow tests with `[!mayfail]` or `[.]` tags for filtering

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -134,6 +134,20 @@ add_custom_command(TARGET AlgorithmSelector_test POST_BUILD
 
 add_test(NAME AlgorithmSelector_test COMMAND AlgorithmSelector_test)
 
+add_executable(PreprocessorSelector_test
+  unit/PreprocessorSelector_test.cpp
+)
+target_link_libraries(PreprocessorSelector_test
+  PRIVATE
+    libmosqueeze
+)
+add_custom_command(TARGET PreprocessorSelector_test POST_BUILD
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different
+          $<TARGET_FILE:libmosqueeze>
+          $<TARGET_FILE_DIR:PreprocessorSelector_test>
+)
+add_test(NAME PreprocessorSelector_test COMMAND PreprocessorSelector_test)
+
 add_executable(BenchmarkConfig_test
   unit/BenchmarkConfig_test.cpp
 )

--- a/tests/unit/BayerPreprocessor_test.cpp
+++ b/tests/unit/BayerPreprocessor_test.cpp
@@ -146,6 +146,47 @@ int main() {
     assert(meta.has_value());
     assert(meta->pattern == mosqueeze::BayerPattern::RGGB);
 
+    // Empty metadata in postprocess should pass through unchanged.
+    {
+        mosqueeze::PreprocessResult emptyMeta{};
+        std::string passthrough = "abcdef";
+        std::istringstream passthroughIn(passthrough);
+        std::ostringstream passthroughOut;
+        preprocessor.postprocess(passthroughIn, passthroughOut, emptyMeta);
+        assert(passthroughOut.str() == passthrough);
+    }
+
+    // Metadata version 2 with invalid region should safely pass through.
+    {
+        mosqueeze::PreprocessResult invalidRegion{};
+        invalidRegion.type = mosqueeze::PreprocessorType::BayerPreprocessor;
+        invalidRegion.metadata = {2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+        std::string transformedData = transformedText;
+        std::istringstream invalidIn(transformedData);
+        std::ostringstream invalidOut;
+        preprocessor.postprocess(invalidIn, invalidOut, invalidRegion);
+        assert(invalidOut.str() == transformedData);
+    }
+
+    // Legacy metadata version 1 restore path should still work.
+    {
+        const std::string legacyOriginal = "abcdefgh";
+        std::string legacyProcessed(legacyOriginal.size(), '\0');
+        const size_t words = legacyOriginal.size() / 2;
+        for (size_t i = 0; i < words; ++i) {
+            legacyProcessed[i] = legacyOriginal[i * 2];
+            legacyProcessed[words + i] = legacyOriginal[(i * 2) + 1];
+        }
+
+        mosqueeze::PreprocessResult legacyMeta{};
+        legacyMeta.type = mosqueeze::PreprocessorType::BayerPreprocessor;
+        legacyMeta.metadata = {1, 8, 0, 0, 0};
+        std::istringstream legacyIn(legacyProcessed);
+        std::ostringstream legacyOut;
+        preprocessor.postprocess(legacyIn, legacyOut, legacyMeta);
+        assert(legacyOut.str() == legacyOriginal);
+    }
+
     std::cout << "[PASS] BayerPreprocessor_test\n";
     return 0;
 }

--- a/tests/unit/DictionaryPreprocessor_test.cpp
+++ b/tests/unit/DictionaryPreprocessor_test.cpp
@@ -4,16 +4,34 @@
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <stdexcept>
 #include <sstream>
 #include <string>
 #include <vector>
 
 int main() {
     namespace fs = std::filesystem;
+    const fs::path tempDir = fs::temp_directory_path() / "mosqueeze_dict_test";
 
     mosqueeze::DictionaryPreprocessor dict;
+    assert(!dict.canProcess(mosqueeze::FileType::Text_Log));
 
-    const fs::path tempDir = fs::temp_directory_path() / "mosqueeze_dict_test";
+    bool emptySamplesThrown = false;
+    try {
+        dict.trainFromSamples({}, 1024);
+    } catch (const std::exception&) {
+        emptySamplesThrown = true;
+    }
+    assert(emptySamplesThrown);
+
+    bool zeroSizeThrown = false;
+    try {
+        dict.trainFromSamples({tempDir / "missing"}, 0);
+    } catch (const std::exception&) {
+        zeroSizeThrown = true;
+    }
+    assert(zeroSizeThrown);
+
     fs::create_directories(tempDir);
     std::vector<fs::path> samples;
     for (int i = 0; i < 120; ++i) {
@@ -26,6 +44,7 @@ int main() {
 
     dict.trainFromSamples(samples, 8 * 1024);
     assert(dict.canProcess(mosqueeze::FileType::Text_Log));
+    assert(dict.estimatedImprovement(mosqueeze::FileType::Text_Log) > 0.0);
 
     const std::string payload = "INFO service=api path=/v1/items id=999 status=200\n";
     std::istringstream in(payload);
@@ -37,6 +56,43 @@ int main() {
     std::ostringstream restored;
     dict.postprocess(processedIn, restored, result);
     assert(restored.str() == payload);
+
+    const fs::path dictPath = tempDir / "test.dict";
+    dict.saveDictionary(dictPath);
+    assert(fs::exists(dictPath));
+
+    mosqueeze::DictionaryPreprocessor loaded;
+    loaded.loadDictionary(dictPath);
+    assert(loaded.canProcess(mosqueeze::FileType::Binary_Chunked));
+    std::istringstream loadedIn(payload);
+    std::ostringstream loadedOut;
+    const auto loadedResult = loaded.preprocess(loadedIn, loadedOut, mosqueeze::FileType::Text_Log);
+    assert(loadedResult.type == mosqueeze::PreprocessorType::DictionaryPreprocessor);
+    assert(loadedOut.str() == payload);
+
+    mosqueeze::DictionaryPreprocessor noDict;
+    bool preprocessWithoutDictionaryThrown = false;
+    try {
+        std::istringstream inNoDict(payload);
+        std::ostringstream outNoDict;
+        (void)noDict.preprocess(inNoDict, outNoDict, mosqueeze::FileType::Text_Log);
+    } catch (const std::exception&) {
+        preprocessWithoutDictionaryThrown = true;
+    }
+    assert(preprocessWithoutDictionaryThrown);
+
+    const fs::path emptySample = tempDir / "empty_sample.bin";
+    {
+        std::ofstream out(emptySample, std::ios::binary);
+    }
+    bool emptyTrainingDataThrown = false;
+    try {
+        mosqueeze::DictionaryPreprocessor emptyDict;
+        emptyDict.trainFromSamples({emptySample}, 1024);
+    } catch (const std::exception&) {
+        emptyTrainingDataThrown = true;
+    }
+    assert(emptyTrainingDataThrown);
 
     fs::remove_all(tempDir);
     std::cout << "[PASS] DictionaryPreprocessor_test\n";

--- a/tests/unit/ImageMetaStripper_test.cpp
+++ b/tests/unit/ImageMetaStripper_test.cpp
@@ -2,11 +2,16 @@
 
 #include <cassert>
 #include <iostream>
+#include <stdexcept>
 #include <sstream>
 #include <string>
 
 int main() {
     mosqueeze::ImageMetaStripper stripper;
+    assert(stripper.canProcess(mosqueeze::FileType::Image_JPEG));
+    assert(stripper.canProcess(mosqueeze::FileType::Image_PNG));
+    assert(stripper.canProcess(mosqueeze::FileType::Image_Raw));
+    assert(!stripper.canProcess(mosqueeze::FileType::Text_Structured));
 
     const std::string jpegLike = "\xFF\xD8\xFF\xE1\x00\x10META\xFF\xD9";
     std::istringstream in(jpegLike);
@@ -18,7 +23,8 @@ int main() {
     std::ostringstream restored;
     stripper.postprocess(stripIn, restored, result);
     assert(restored.str() == jpegLike);
-    assert(stripper.canProcess(mosqueeze::FileType::Image_Raw));
+    assert(result.type == mosqueeze::PreprocessorType::ImageMetaStripper);
+    assert(result.processedBytes == jpegLike.size());
 
     const std::string tiffLike = "II*\x00\x08\x00\x00\x00rawdata";
     std::istringstream rawIn(tiffLike);
@@ -31,6 +37,24 @@ int main() {
     std::ostringstream rawRestored;
     stripper.postprocess(rawStripIn, rawRestored, rawResult);
     assert(rawRestored.str() == tiffLike);
+
+    const std::string empty;
+    std::istringstream emptyIn(empty);
+    std::ostringstream emptyOut;
+    const auto emptyResult = stripper.preprocess(emptyIn, emptyOut, mosqueeze::FileType::Image_PNG);
+    assert(emptyResult.originalBytes == 0);
+    assert(emptyResult.processedBytes == 0);
+    assert(emptyOut.str().empty());
+
+    bool wrongTypeThrown = false;
+    try {
+        std::istringstream wrongType("x");
+        std::ostringstream ignored;
+        (void)stripper.preprocess(wrongType, ignored, mosqueeze::FileType::Text_Prose);
+    } catch (const std::exception&) {
+        wrongTypeThrown = true;
+    }
+    assert(wrongTypeThrown);
 
     std::cout << "[PASS] ImageMetaStripper_test\n";
     return 0;

--- a/tests/unit/JsonCanonicalizer_test.cpp
+++ b/tests/unit/JsonCanonicalizer_test.cpp
@@ -2,16 +2,22 @@
 
 #include <cassert>
 #include <iostream>
+#include <stdexcept>
 #include <sstream>
 #include <string>
 
 int main() {
     mosqueeze::JsonCanonicalizer canon;
     const std::string input = R"({"z":1,"a":{"x":2,"b":3}})";
+    const std::string equivalent = R"({ "a" : { "b" : 3, "x" : 2 }, "z" : 1 })";
 
     std::istringstream in(input);
     std::ostringstream preprocessed;
     const auto result = canon.preprocess(in, preprocessed, mosqueeze::FileType::Text_Structured);
+
+    std::istringstream inEquivalent(equivalent);
+    std::ostringstream preprocessedEquivalent;
+    const auto resultEquivalent = canon.preprocess(inEquivalent, preprocessedEquivalent, mosqueeze::FileType::Text_Structured);
 
     std::istringstream preIn(preprocessed.str());
     std::ostringstream restored;
@@ -19,8 +25,41 @@ int main() {
 
     assert(restored.str() == input);
     assert(!preprocessed.str().empty());
+    assert(preprocessedEquivalent.str() == preprocessed.str());
     assert(preprocessed.str().find("\"a\"") != std::string::npos);
     assert(preprocessed.str().find("\"z\"") != std::string::npos);
+    assert(result.type == mosqueeze::PreprocessorType::JsonCanonicalizer);
+    assert(result.metadata.size() == input.size());
+    assert(resultEquivalent.type == mosqueeze::PreprocessorType::JsonCanonicalizer);
+
+    // postprocess fallback path when metadata is absent.
+    mosqueeze::PreprocessResult emptyMeta{};
+    std::istringstream passthroughIn("{\"a\":1}");
+    std::ostringstream passthroughOut;
+    canon.postprocess(passthroughIn, passthroughOut, emptyMeta);
+    assert(passthroughOut.str() == "{\"a\":1}");
+
+    // malformed JSON must throw.
+    bool malformedThrown = false;
+    try {
+        std::istringstream malformed(R"({"a":)");
+        std::ostringstream ignored;
+        (void)canon.preprocess(malformed, ignored, mosqueeze::FileType::Text_Structured);
+    } catch (const std::exception&) {
+        malformedThrown = true;
+    }
+    assert(malformedThrown);
+
+    // wrong file type must throw.
+    bool wrongTypeThrown = false;
+    try {
+        std::istringstream wrongType(input);
+        std::ostringstream ignored;
+        (void)canon.preprocess(wrongType, ignored, mosqueeze::FileType::Image_JPEG);
+    } catch (const std::exception&) {
+        wrongTypeThrown = true;
+    }
+    assert(wrongTypeThrown);
 
     std::cout << "[PASS] JsonCanonicalizer_test\n";
     return 0;

--- a/tests/unit/PreprocessorSelector_test.cpp
+++ b/tests/unit/PreprocessorSelector_test.cpp
@@ -1,0 +1,65 @@
+#include <mosqueeze/PreprocessorSelector.hpp>
+
+#include <algorithm>
+#include <cassert>
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace {
+
+bool containsName(const std::vector<std::string>& names, const std::string& expected) {
+    return std::find(names.begin(), names.end(), expected) != names.end();
+}
+
+bool containsType(const std::vector<mosqueeze::IPreprocessor*>& preprocessors, const std::string& expectedName) {
+    return std::any_of(preprocessors.begin(), preprocessors.end(), [&](const auto* preprocessor) {
+        return preprocessor != nullptr && preprocessor->name() == expectedName;
+    });
+}
+
+} // namespace
+
+int main() {
+    mosqueeze::PreprocessorSelector selector;
+
+    const auto names = selector.listNames();
+    assert(names.size() == 5);
+    assert(containsName(names, "json-canonical"));
+    assert(containsName(names, "xml-canonical"));
+    assert(containsName(names, "image-meta-strip"));
+    assert(containsName(names, "bayer-raw"));
+    assert(containsName(names, "zstd-dict"));
+
+    const auto structuredApplicable = selector.getApplicable(mosqueeze::FileType::Text_Structured);
+    assert(structuredApplicable.size() == 2);
+    assert(containsType(structuredApplicable, "json-canonical"));
+    assert(containsType(structuredApplicable, "xml-canonical"));
+
+    const auto rawApplicable = selector.getApplicable(mosqueeze::FileType::Image_Raw);
+    assert(rawApplicable.size() == 2);
+    assert(containsType(rawApplicable, "bayer-raw"));
+    assert(containsType(rawApplicable, "image-meta-strip"));
+
+    const auto jpegApplicable = selector.selectChain(mosqueeze::FileType::Image_JPEG);
+    assert(jpegApplicable.size() == 1);
+    assert(jpegApplicable.front()->name() == "image-meta-strip");
+
+    auto* bestStructured = selector.selectBest(mosqueeze::FileType::Text_Structured);
+    assert(bestStructured != nullptr);
+    assert(bestStructured->name() == "json-canonical");
+
+    auto* bestRaw = selector.selectBest(mosqueeze::FileType::Image_Raw);
+    assert(bestRaw != nullptr);
+    assert(bestRaw->name() == "bayer-raw");
+
+    auto* bestJpeg = selector.selectBest(mosqueeze::FileType::Image_JPEG);
+    assert(bestJpeg != nullptr);
+    assert(bestJpeg->name() == "image-meta-strip");
+
+    auto* bestUnknown = selector.selectBest(mosqueeze::FileType::Unknown);
+    assert(bestUnknown == nullptr);
+
+    std::cout << "[PASS] PreprocessorSelector_test\n";
+    return 0;
+}

--- a/tests/unit/XmlCanonicalizer_test.cpp
+++ b/tests/unit/XmlCanonicalizer_test.cpp
@@ -2,6 +2,7 @@
 
 #include <cassert>
 #include <iostream>
+#include <stdexcept>
 #include <sstream>
 #include <string>
 
@@ -20,6 +21,37 @@ int main() {
     assert(!preprocessed.str().empty());
     assert(preprocessed.str().find("<root>") != std::string::npos);
     assert(preprocessed.str().find("</root>") != std::string::npos);
+    assert(result.type == mosqueeze::PreprocessorType::XmlCanonicalizer);
+    assert(result.metadata.size() == input.size());
+
+    // postprocess fallback path when metadata is absent.
+    mosqueeze::PreprocessResult emptyMeta{};
+    std::istringstream passthroughIn("<x/>");
+    std::ostringstream passthroughOut;
+    canon.postprocess(passthroughIn, passthroughOut, emptyMeta);
+    assert(passthroughOut.str() == "<x/>");
+
+    // malformed XML must throw.
+    bool malformedThrown = false;
+    try {
+        std::istringstream malformed("<root>");
+        std::ostringstream ignored;
+        (void)canon.preprocess(malformed, ignored, mosqueeze::FileType::Text_Structured);
+    } catch (const std::exception&) {
+        malformedThrown = true;
+    }
+    assert(malformedThrown);
+
+    // wrong file type must throw.
+    bool wrongTypeThrown = false;
+    try {
+        std::istringstream wrongType(input);
+        std::ostringstream ignored;
+        (void)canon.preprocess(wrongType, ignored, mosqueeze::FileType::Image_JPEG);
+    } catch (const std::exception&) {
+        wrongTypeThrown = true;
+    }
+    assert(wrongTypeThrown);
 
     std::cout << "[PASS] XmlCanonicalizer_test\n";
     return 0;


### PR DESCRIPTION
## Summary
- Add a dedicated `PreprocessorSelector_test` to verify registration and file-type selection
- Expand existing preprocessor tests with round-trip, edge-case, and error-path coverage
- Document a focused `ctest` command for running the preprocessor suite

## Testing
- Built the updated preprocessor test targets locally
- Ran the preprocessor-focused `ctest` subset successfully