### PR TITLE
Add RAW format safety controls for Bayer preprocessing

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,25 @@ mosqueeze v0.1.0
 # Run benchmark with automatic preprocessing selection
 ./build/src/mosqueeze-bench/mosqueeze-bench --directory ./benchmarks/corpus --preprocess auto --default-only --verbose
 
+# Check RAW format detection/compression classification for Bayer preprocessing
+./build/src/mosqueeze-bench/mosqueeze-bench --directory ./raw --preprocess bayer-raw --dry-run
+
+# Force Bayer preprocessing even when RAW is detected as compressed
+./build/src/mosqueeze-bench/mosqueeze-bench --directory ./raw --preprocess bayer-raw --force-bayer
+
 # Export HTML report
 ./build/src/mosqueeze-bench/mosqueeze-bench --directory ./benchmarks/corpus --export ./benchmarks/results/report.html --format html
 ```
+
+## RAW format support
+
+Bayer preprocessing now classifies RAW payloads before transforming:
+
+- `Uncompressed`: processed normally
+- `Lossless compressed`: skipped by default (no expected gain), unless `--force-bayer`
+- `Lossy compressed`: rejected to avoid harmful transforms
+
+Current detector coverage includes: RAF, ARW, CR2, CR3, NEF/NRW (by extension), IIQ, 3FR, DNG.
 
 ## Run Tests
 

--- a/docs/features/feat-53-raw-format-support.md
+++ b/docs/features/feat-53-raw-format-support.md
@@ -1,0 +1,550 @@
+# Worker Spec: Support for Uncompressed RAW Formats
+
+**Issue:** #53 - Feature: Support for Uncompressed RAW Formats  
+**Branch:** `feat/raw-format-support`  
+**Priority:** Medium  
+**Estimated Effort:** 2-3 days  
+**Depends on:** #46 (BayerPreprocessor RAF parsing - MERGED)  
+
+---
+
+## Overview
+
+Extend BayerPreprocessor to truly uncompressed RAW formats. The current implementation shows **no improvement** on Fujifilm RAF files because they use "Lossless Compressed RAW" internally. This feature adds format detection and proper handling for uncompressed RAW formats.
+
+---
+
+## Problem Statement
+
+### Current findings (BayerPreprocessor benchmark v2)
+
+| File | Original | Compressed | Ratio | With BayerPreprocessor | Ratio |
+|------|----------|------------|-------|------------------------|-------|
+| RAF (compressed) | 27MB | 24.3MB | 0.90x | 24.3MB | 0.90x **(no improvement)** |
+
+**Root cause:** Fujifilm "Lossless Compressed RAW":
+- Camera compresses RAW data internally (~2x compression)
+- 27MB compressed vs ~52MB uncompressed equivalent
+- Bayer patterns destroyed by compression entropy
+- BayerPreprocessor cannot improve already-compressed data
+
+### What we need
+
+**Truly uncompressed RAW** where BayerPreprocessor provides benefit:
+- Uncompressed Phase One IIQ
+- Uncompressed Hasselblad 3FR  
+- Uncompressed Sony ARW
+- Uncompressed Nikon NEF
+- Uncompressed Canon CR3/CR2
+- Uncompressed DNG
+
+**Expected improvement:** 15-25% additional compression on uncompressed RAW.
+
+---
+
+## Solution Architecture
+
+### Format Detection System
+
+```cpp
+// src/libmosqueeze/include/mosqueeze/RawFormat.hpp
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <optional>
+#include <string_view>
+
+namespace mosqueeze {
+
+enum class RawCompression {
+    Uncompressed,        // BayerPreprocessor beneficial ✓
+    LosslessCompressed,  // BayerPreprocessor ineffective ✗
+    LossyCompressed,     // BayerPreprocessor HARMFUL - reject ⚠
+    Unknown              // Conservative: skip ?
+};
+
+struct RawFormatInfo {
+    std::string_view extension;      // ".RAF", ".ARW", etc.
+    std::string_view manufacturer;    // "Fujifilm", "Sony", etc.
+    RawCompression compression;      // Detected compression type
+    std::string_view compressionName; // "Lossless Compressed RAW"
+    bool isUncompressedAvailable;    // Camera supports uncompressed mode
+    std::string_view notes;          // Human-readable notes
+};
+
+class RawFormatDetector {
+public:
+    // Detect format from magic bytes
+    static std::optional<RawFormatInfo> detect(std::span<const uint8_t> data);
+    
+    // Detect from file extension (fallback)
+    static std::optional<RawFormatInfo> detectByExtension(std::string_view filename);
+    
+    // Check if BayerPreprocessor should be applied
+    static bool shouldApplyBayerPreprocessor(RawCompression compression) {
+        return compression == RawCompression::Uncompressed;
+    }
+    
+private:
+    // Magic byte signatures
+    static constexpr auto FUJIFILM_RAF = std::array{'F', 'U', 'J', 'I', 'F', 'I', 'L', 'M'};
+    static constexpr auto SONY_ARW = std::array{'S', 'O', 'N', 'Y', ' ', 'D', 'S', 'C'};
+    static constexpr auto CANON_CR2 = std::array{'I', 'I', '*', 0x10, 0x00, 0x00, 0x00, 0x43};
+    static constexpr auto CANON_CR3 = std::array{0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70};
+    static constexpr auto NIKON_NEF = std::array{'N', 'E', 'F', 0x00};
+    static constexpr auto PHASEONE_IIQ = std::array{'I', 'I', 'Q', 0x00};
+    static constexpr auto HASSELBLAD_3FR = std::array{'H', '3', 'D'}; // or '3','F','R'
+    static constexpr auto ADOBE_DNG = std::array{'I', 'I', '*', 0x00, 0x00, 0x00, 0x14}; // TIFF-based
+};
+
+} // namespace mosqueeze
+```
+
+### Format Detection Implementation
+
+```cpp
+// src/libmosqueeze/src/RawFormat.cpp
+#include "mosqueeze/RawFormat.hpp"
+#include <algorithm>
+
+namespace mosqueeze {
+
+std::optional<RawFormatInfo> RawFormatDetector::detect(std::span<const uint8_t> data) {
+    if (data.size() < 16) return std::nullopt;
+    
+    // Fujifilm RAF
+    if (std::equal(FUJIFILM_RAF.begin(), FUJIFILM_RAF.end(), data.begin())) {
+        // Check compression type in RAF header
+        // Offset 84: compression type (1 = lossless compressed, 0 = uncompressed)
+        uint8_t compressionType = data.size() > 84 ? data[84] : 0xFF;
+        return RawFormatInfo{
+            .extension = ".RAF",
+            .manufacturer = "Fujifilm",
+            .compression = (compressionType == 1) ? RawCompression::LosslessCompressed 
+                                                    : RawCompression::Uncompressed,
+            .compressionName = (compressionType == 1) ? "Lossless Compressed RAW" 
+                                                        : "Uncompressed RAW",
+            .isUncompressedAvailable = true,
+            .notes = "Fujifilm default is Lossless Compressed; Uncompressed mode available"
+        };
+    }
+    
+    // Sony ARW
+    if (std::equal(SONY_ARW.begin(), SONY_ARW.end(), data.begin())) {
+        // Sony ARW 1.0/2.0/2.1/2.2/2.3/3.0
+        // Check bit depth and compression flag
+        uint16_t version = (data[8] << 8) | data[9];
+        // Most Sony RAWs are compressed by default
+        return RawFormatInfo{
+            .extension = ".ARW",
+            .manufacturer = "Sony",
+            .compression = RawCompression::Unknown, // Need more context
+            .compressionName = "Unknown",
+            .isUncompressedAvailable = true,
+            .notes = "Check camera settings for 'Uncompressed RAW' option"
+        };
+    }
+    
+    // Canon CR2 (TIFF-based)
+    if (std::equal(CANON_CR2.begin(), CANON_CR2.end(), data.begin())) {
+        // CR2 version is at offset 8
+        uint16_t cr2Version = (data[8] << 8) | data[9];
+        return RawFormatInfo{
+            .extension = ".CR2",
+            .manufacturer = "Canon",
+            .compression = RawCompression::Unknown,
+            .compressionName = "Unknown",
+            .isUncompressedAvailable = true,
+            .notes = "Check compression tag in EXIF"
+        };
+    }
+    
+    // Canon CR3 (ISOBMFF-based)
+    if (std::equal(CANON_CR3.begin(), CANON_CR3.end(), data.begin())) {
+        return RawFormatInfo{
+            .extension = ".CR3",
+            .manufacturer = "Canon",
+            .compression = RawCompression::Unknown,
+            .compressionName = "Unknown",
+            .isUncompressedAvailable = true,
+            .notes = "CR3 uses image tiles; check tile compression"
+        };
+    }
+    
+    // Nikon NEF
+    if (std::equal(NIKON_NEF.begin(), NIKON_NEF.end(), data.begin())) {
+        return RawFormatInfo{
+            .extension = ".NEF",
+            .manufacturer = "Nikon",
+            .compression = RawCompression::Unknown,
+            .compressionName = "Unknown",
+            .isUncompressedAvailable = true,
+            .notes = "Nikon default is Lossless Compressed"
+        };
+    }
+    
+    // Phase One IIQ
+    if (std::equal(PHASEONE_IIQ.begin(), PHASEONE_IIQ.end(), data.begin())) {
+        return RawFormatInfo{
+            .extension = ".IIQ",
+            .manufacturer = "Phase One",
+            .compression = RawCompression::Uncompressed, // Usually uncompressed
+            .compressionName = "Uncompressed",
+            .isUncompressedAvailable = true,
+            .notes = "Phase One IIQ is typically uncompressed"
+        };
+    }
+    
+    // Hasselblad 3FR
+    if (std::equal(HASSELBLAD_3FR.begin(), HASSELBLAD_3FR.end(), data.begin())) {
+        return RawFormatInfo{
+            .extension = ".3FR",
+            .manufacturer = "Hasselblad",
+            .compression = RawCompression::Uncompressed,
+            .compressionName = "Uncompressed",
+            .isUncompressedAvailable = true,
+            .notes = "Hasselblad 3FR is typically uncompressed"
+        };
+    }
+    
+    // Adobe DNG
+    if (std::equal(ADOBE_DNG.begin(), ADOBE_DNG.end(), data.begin())) {
+        // DNG can be anything - check SubIFD compression tag
+        return RawFormatInfo{
+            .extension = ".DNG",
+            .manufacturer = "Adobe",
+            .compression = RawCompression::Unknown,
+            .compressionName = "Depends on source",
+            .isUncompressedAvailable = true,
+            .notes = "DNG compression follows source camera"
+        };
+    }
+    
+    return std::nullopt; // Unknown format
+}
+
+std::optional<RawFormatInfo> RawFormatDetector::detectByExtension(std::string_view filename) {
+    auto dot = filename.rfind('.');
+    if (dot == std::string_view::npos) return std::nullopt;
+    
+    auto ext = filename.substr(dot);
+    // Convert to uppercase
+    std::string extUpper(ext);
+    std::transform(extUpper.begin(), extUpper.end(), extUpper.begin(), ::toupper);
+    
+    if (extUpper == ".RAF") {
+        return RawFormatInfo{
+            .extension = ".RAF",
+            .manufacturer = "Fujifilm",
+            .compression = RawCompression::LosslessCompressed, // Default assumption
+            .compressionName = "Lossless Compressed RAW (assumed)",
+            .isUncompressedAvailable = true,
+            .notes = "Most Fujifilm RAF is Lossless Compressed"
+        };
+    }
+    
+    // Similar for other formats...
+    return std::nullopt;
+}
+
+} // namespace mosqueeze
+```
+
+---
+
+## BayerPreprocessor Integration
+
+### Updated BayerPreprocessor.cpp
+
+```cpp
+// src/libmosqueeze/src/preprocessors/BayerPreprocessor.cpp
+
+#include "mosqueeze/RawFormat.hpp"
+#include "mosqueeze/preprocessors/BayerPreprocessor.hpp"
+
+namespace mosqueeze {
+
+std::expected<std::vector<uint8_t>, PreprocessError>
+BayerPreprocessor::preprocess(std::span<const uint8_t> data) {
+    // Detect RAW format
+    auto format = RawFormatDetector::detect(data);
+    
+    if (!format) {
+        // Unknown format - conservative: try to process
+        // (may work on uncompressed RAW from unknown cameras)
+        spdlog::warn("Unknown RAW format, attempting BayerPreprocessor anyway");
+    } else {
+        // Log detected format
+        spdlog::info("Detected {} {} ({})", 
+            format->manufacturer, 
+            format->extension, 
+            format->compressionName);
+        
+        // Check if BayerPreprocessor is appropriate
+        if (!RawFormatDetector::shouldApplyBayerPreprocessor(format->compression)) {
+            if (format->compression == RawCompression::LosslessCompressed) {
+                spdlog::warn(
+                    "{} uses {} - BayerPreprocessor provides no benefit. "
+                    "Use --force-bayer to process anyway.",
+                    format->manufacturer, 
+                    format->compressionName
+                );
+                
+                if (!forceProcess_) {
+                    return std::unexpected(PreprocessError{
+                        .code = ErrorCode::FormatNotSupported,
+                        .message = fmt::format(
+                            "{} is already compressed ({}). BayerPreprocessor ineffective.",
+                            format->manufacturer,
+                            format->compressionName
+                        )
+                    });
+                }
+            } else if (format->compression == RawCompression::LossyCompressed) {
+                spdlog::error(
+                    "{} uses lossy compression - BayerPreprocessor would HARM data!",
+                    format->manufacturer
+                );
+                return std::unexpected(PreprocessError{
+                    .code = ErrorCode::HarmfulOperation,
+                    .message = fmt::format(
+                        "{} is lossy compressed. BayerPreprocessor would corrupt data.",
+                        format->manufacturer
+                    )
+                });
+            }
+        }
+    }
+    
+    // Continue with existing BayerPreprocessor logic...
+    // (parse RAF header, extract Bayer data, transform, etc.)
+}
+
+} // namespace mosqueeze
+```
+
+---
+
+## CLI Integration
+
+### New Flags
+
+```cpp
+// --preprocess bayer-raw behavior changes:
+// 1. Detects format and compression type
+// 2. Skips already-compressed RAW (with warning)
+// 3. Rejects lossy-compressed RAW (error)
+// 4. Processes uncompressed RAW normally
+
+// --force-bayer
+// Processes even if format is detected as already-compressed
+// Use ONLY if you know the file is truly uncompressed
+
+// --dry-run
+// Reports what would be done without processing
+// Useful for "what compression type is this RAW?"
+```
+
+### CLI Output
+
+```
+$ mosqueeze-bench -d ./raw/ -a zstd --preprocess bayer-raw
+
+Detecting RAW formats...
+
+[DNG] ./phase1.iiq
+  → Phase One IIQ (Uncompressed) - BayerPreprocessor will be applied ✓
+
+[RAF] ./fuji.raf
+  → Fujifilm RAF (Lossless Compressed RAW) - SKIPPED
+  ⚠ BayerPreprocessor provides no benefit. Use --force-bayer to process anyway.
+
+[ARW] ./sony.arw
+  → Sony ARW (compression unknown) - Proceeding with caution
+  ℹ If this is Lossless Compressed, BayerPreprocessor won't help.
+
+Processing ./phase1.iiq with BayerPrepressor...
+  Original: 52.3 MB
+  Post-BayerPreprocessor: 48.1 MB (7-8% reduction)
+  Final (zstd): 42.2 MB (19% total compression)
+```
+
+---
+
+## Test Cases
+
+```cpp
+TEST_CASE("RawFormatDetector: Fujifilm RAF Lossless Compressed") {
+    auto data = loadRafFile("fuji_lossless.raf");
+    auto format = RawFormatDetector::detect(data);
+    REQUIRE(format.has_value());
+    REQUIRE(format->extension == ".RAF");
+    REQUIRE(format->compression == RawCompression::LosslessCompressed);
+    REQUIRE_FALSE(RawFormatDetector::shouldApplyBayerPreprocessor(format->compression));
+}
+
+TEST_CASE("RawFormatDetector: Fujifilm RAF Uncompressed") {
+    auto data = loadRafFile("fuji_uncompressed.raf");
+    auto format = RawFormatDetector::detect(data);
+    REQUIRE(format.has_value());
+    REQUIRE(format->compression == RawCompression::Uncompressed);
+    REQUIRE(RawFormatDetector::shouldApplyBayerPreprocessor(format->compression));
+}
+
+TEST_CASE("RawFormatDetector: Phase One IIQ") {
+    auto data = loadIiqFile("phase1.iiq");
+    auto format = RawFormatDetector::detect(data);
+    REQUIRE(format.has_value());
+    REQUIRE(format->extension == ".IIQ");
+    REQUIRE(format->compression == RawCompression::Uncompressed);
+}
+
+TEST_CASE("BayerPreprocessor: Skip Lossless Compressed") {
+    BayerPreprocessor bp;
+    auto data = loadRafFile("fuji_lossless.raf");
+    auto result = bp.preprocess(data);
+    REQUIRE(!result.has_value());
+    REQUIRE(result.error().code == ErrorCode::FormatNotSupported);
+}
+
+TEST_CASE("BayerPreprocessor: Force Process Compressed") {
+    BayerPreprocessor bp(/*force=*/true);
+    auto data = loadRafFile("fuji_lossless.raf");
+    auto result = bp.preprocess(data);
+    REQUIRE(result.has_value()); // Processes anyway
+}
+
+TEST_CASE("BayerPreprocessor: Reject Lossy Compressed") {
+    BayerPreprocessor bp(/*force=*/true);
+    auto data = loadFile("lossy_compressed.raw");
+    auto result = bp.preprocess(data);
+    REQUIRE(!result.has_value());
+    REQUIRE(result.error().code == ErrorCode::HarmfulOperation);
+}
+```
+
+---
+
+## Implementation Steps
+
+### Phase 1: Format Detection (1 day)
+- [ ] Create `RawFormat.hpp` with enum and struct
+- [ ] Implement `RawFormatDetector::detect()` for major formats
+- [ ] Add magic byte signatures for all supported formats
+- [ ] Write unit tests for format detection
+- [ ] Add format detection to CLI `--dry-run` mode
+
+### Phase 2: BayerPreprocessor Integration (1 day)
+- [ ] Add `force_` flag to BayerPreprocessor
+- [ ] Add format check at start of `preprocess()`
+- [ ] Skip with warning for LosslessCompressed
+- [ ] Reject with error for LossyCompressed
+- [ ] Log detected format and compression type
+
+### Phase 3: CLI Updates (0.5 day)
+- [ ] Add `--force-bayer` flag
+- [ ] Add `--dry-run` detection mode
+- [ ] Update help text with format support info
+- [ ] Add format support documentation to README
+
+### Phase 4: Testing (0.5 day)
+- [ ] Create test fixtures for each format type
+- [ ] Test with actual uncompressed RAW files (if available)
+- [ ] Verify rejection of lossy formats
+- [ ] Benchmark on uncompressed RAW (expect 15-25% improvement)
+
+---
+
+## Test Fixtures Needed
+
+1. **Fujifilm RAF** - Both compressed and uncompressed (if possible)
+2. **Phase One IIQ** - Typically uncompressed
+3. **Hasselblad 3FR** - Typically uncompressed  
+4. **Sony ARW** - Compressed and uncompressed variants
+5. **Canon CR2/CR3** - Compressed and uncompressed variants
+6. **Nikon NEF** - Compressed and uncompressed variants
+7. **Adobe DNG** - Various source formats
+
+> Note: May need to source test files from photographers or generate synthetic RAW data.
+
+---
+
+## Benchmark Targets
+
+Expected BayerPreprocessor improvement on **uncompressed** RAW:
+
+| Format | Typical Size | Expected Improvement |
+|--------|-------------|---------------------|
+| Phase One IIQ | 50-80 MB | 15-25% |
+| Hasselblad 3FR | 40-70 MB | 15-25% |
+| Sony ARW (uncompressed) | 40-50 MB | 10-20% |
+| Nikon NEF (uncompressed) | 35-45 MB | 10-15% |
+| DNG (uncompressed) | Varies | 15-25% |
+
+---
+
+## Documentation
+
+### README.md Addition
+
+```markdown
+## Supported RAW Formats
+
+BayerPreprocessor effectiveness depends on RAW compression type:
+
+| Manufacturer | Format | Compression | BayerPreprocessor |
+|--------------|--------|-------------|-------------------|
+| Fujifilm | RAF | Lossless Compressed | ⚠ No benefit (default) |
+| Fujifilm | RAF | Uncompressed | ✓ Beneficial |
+| Phase One | IIQ | Uncompressed | ✓ Beneficial |
+| Hasselblad | 3FR | Uncompressed | ✓ Beneficial |
+| Sony | ARW | Uncompressed | ✓ Beneficial |
+| Sony | ARW | Compressed | ⚠ No benefit |
+| Nikon | NEF | Uncompressed | ✓ Beneficial |
+| Nikon | NEF | Lossless Compressed | ⚠ No benefit |
+| Canon | CR2/CR3 | Uncompressed | ✓ Beneficial |
+| Canon | CR2/CR3 | Compressed | ⚠ No benefit |
+| Adobe | DNG | Depends on source | Check original |
+
+Use `mosqueeze-bench --preprocess bayer-raw --dry-run` to check your files.
+```
+
+---
+
+## Acceptance Criteria
+
+- [ ] Format detection for Fujifilm RAF, Sony ARW, Canon CR2/CR3, Nikon NEF, Phase One IIQ, Hasselblad 3FR, Adobe DNG
+- [ ] Auto-skip for LosslessCompressed RAW with warning
+- [ ] Reject LossyCompressed RAW with error (cannot be processed safely)
+- [ ] `--force-bayer` flag to override skip behavior
+- [ ] `--dry-run` mode for format detection only
+- [ ] Unit tests for all supported formats
+- [ ] Documentation updated with format support table
+- [ ] CLI reports detected format and compression type
+- [ ] Benchmark on at least one uncompressed RAW format (if available)
+
+---
+
+## Related Issues
+
+- #46: BayerPreprocessor RAF parsing (foundation)
+- #52: Preprocessor Unit Test Suite (tests needed)
+
+---
+
+## Risks
+
+1. **Test files availability** - Uncompressed RAW files are large and may be hard to source
+2. **Format variations** - Camera firmware may change format details
+3. **False positives** - Incorrect format detection could cause data loss
+4. **Performance** - Format detection adds minimal overhead but should be profiled
+
+---
+
+## Future Enhancements
+
+- Automatic compression detection via EXIF/TIFF tags
+- Support for additional RAW formats (Panasonic RW2, Olympus ORF, etc.)
+- Synthetic test fixture generation
+- Camera model specific optimizations

--- a/docs/wiki/guides/benchmark-tool.md
+++ b/docs/wiki/guides/benchmark-tool.md
@@ -2,7 +2,7 @@
 
 **Summary**: Practical guide for the enhanced benchmark CLI implemented in Issue #23.
 
-**Last updated**: 2026-04-22
+**Last updated**: 2026-04-23
 
 ---
 
@@ -15,6 +15,7 @@
 - repeated runs with warmup (`--iterations`, `--warmup`)
 - optional decode and memory tracking (`--no-decode`, `--no-memory`)
 - optional preprocessing (`--preprocess none|auto|bayer-raw|image-meta-strip|json-canonical|xml-canonical`)
+- RAW safety controls for Bayer preprocessing (`--force-bayer` + RAW classification in `--dry-run`)
 - live in-place progress feedback (enabled by default, suppressed by `--quiet`)
 - result exports (`json`, `csv`, `markdown`, `html`)
 - previous run comparison (`--compare`, `--diff-only`)
@@ -78,6 +79,7 @@ Benchmark:
       --decode
       --no-decode
       --preprocess MODE   (none|auto|bayer-raw|image-meta-strip|json-canonical|xml-canonical)
+      --force-bayer
 
 Output:
   -o, --output DIR
@@ -136,7 +138,19 @@ Misc:
 
 # Baseline run without preprocessing for A/B comparison
 ./mosqueeze-bench --directory ./raw --preprocess none --output ./benchmarks/results/no-pre
+
+# Inspect RAW compression classification before running Bayer preprocessing
+./mosqueeze-bench --directory ./raw --preprocess bayer-raw --dry-run
+
+# Override skip behavior for lossless-compressed RAW
+./mosqueeze-bench --directory ./raw --preprocess bayer-raw --force-bayer
 ```
+
+`bayer-raw` handling now depends on RAW compression classification:
+
+- `uncompressed`: preprocessing applied
+- `lossless-compressed`: skipped by default (can be overridden with `--force-bayer`)
+- `lossy-compressed`: rejected for safety
 
 ---
 

--- a/docs/wiki/log.md
+++ b/docs/wiki/log.md
@@ -94,3 +94,7 @@ Initial wiki population for Issue #16 â€” focus on algorithmic decision-mak
 - Updated `preprocessing.md` with `bayer-raw` RAF region-only transform behavior
 - Documented safe fallback mode for unparseable/non-RAF raw payloads
 - Documented metadata compatibility (`version 2` region mode + legacy `version 1`)
+
+### Feature Docs: RAW Format Support (Issue #53)
+- Updated `guides/benchmark-tool.md` with `--force-bayer` and Bayer RAW dry-run classification flow
+- Updated `preprocessing.md` with RAW compression classification behavior (uncompressed/lossless/lossy)

--- a/docs/wiki/preprocessing.md
+++ b/docs/wiki/preprocessing.md
@@ -24,6 +24,16 @@ Current behavior:
 - unparseable/non-RAF RAW payloads safely fall back to pass-through (`metadata version 0`)
 - postprocess supports both new region-based metadata (`version 2`) and legacy full-file metadata (`version 1`)
 
+## RAW Compression Classification
+
+`bayer-raw` now classifies RAW compression before transforming:
+
+- `Uncompressed`: transform is applied
+- `Lossless compressed`: skipped by default (`metadata version 0`) because improvement is typically negligible
+- `Lossy compressed`: rejected to avoid harmful transforms
+
+For benchmark workflows, use `--force-bayer` to override the default skip for lossless-compressed files, and use `--dry-run` to print per-file RAW classification.
+
 ## Available Preprocessors
 
 | Name | File Types | Typical Improvement (Target) |

--- a/src/libmosqueeze/CMakeLists.txt
+++ b/src/libmosqueeze/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(libmosqueeze SHARED
   src/engines/BrotliEngine.cpp
   src/engines/ZpaqEngine.cpp
   src/FileTypeDetector.cpp
+  src/RawFormat.cpp
   src/AlgorithmSelector.cpp
   src/PreprocessorSelector.cpp
   src/CompressionPipeline.cpp

--- a/src/libmosqueeze/include/mosqueeze/RawFormat.hpp
+++ b/src/libmosqueeze/include/mosqueeze/RawFormat.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <span>
+#include <string_view>
+
+namespace mosqueeze {
+
+enum class RawCompression : uint8_t {
+    Uncompressed = 0,
+    LosslessCompressed = 1,
+    LossyCompressed = 2,
+    Unknown = 255
+};
+
+struct RawFormatInfo {
+    std::string_view extension;
+    std::string_view manufacturer;
+    RawCompression compression = RawCompression::Unknown;
+    std::string_view compressionName;
+    bool isUncompressedAvailable = false;
+    std::string_view notes;
+};
+
+class RawFormatDetector {
+public:
+    static std::optional<RawFormatInfo> detect(std::span<const uint8_t> data);
+    static std::optional<RawFormatInfo> detectByExtension(std::string_view filename);
+    static bool shouldApplyBayerPreprocessor(RawCompression compression) {
+        return compression == RawCompression::Uncompressed;
+    }
+};
+
+} // namespace mosqueeze

--- a/src/libmosqueeze/include/mosqueeze/bench/BenchmarkConfig.hpp
+++ b/src/libmosqueeze/include/mosqueeze/bench/BenchmarkConfig.hpp
@@ -53,6 +53,7 @@ struct BenchmarkConfig {
     int threadCount = 0;
     bool sequential = false;
     std::string preprocessMode = "none";
+    bool forceBayer = false;
 
     std::function<void(const ProgressInfo&)> onProgress;
     std::function<bool()> shouldCancel;

--- a/src/libmosqueeze/include/mosqueeze/preprocessors/BayerPreprocessor.hpp
+++ b/src/libmosqueeze/include/mosqueeze/preprocessors/BayerPreprocessor.hpp
@@ -30,6 +30,9 @@ struct RawMetadata {
 
 class BayerPreprocessor : public IPreprocessor {
 public:
+    explicit BayerPreprocessor(bool forceProcess = false)
+        : forceProcess_(forceProcess) {}
+
     PreprocessorType type() const override { return PreprocessorType::BayerPreprocessor; }
     std::string name() const override { return "bayer-raw"; }
     bool canProcess(FileType fileType) const override { return fileType == FileType::Image_Raw; }
@@ -50,6 +53,12 @@ public:
 
     static BayerPattern detectPattern(const std::vector<uint8_t>& data);
     static std::optional<RawMetadata> extractMetadata(const std::vector<uint8_t>& data);
+
+    void setForceProcess(bool forceProcess) { forceProcess_ = forceProcess; }
+    bool forceProcess() const { return forceProcess_; }
+
+private:
+    bool forceProcess_ = false;
 };
 
 } // namespace mosqueeze

--- a/src/libmosqueeze/src/FileTypeDetector.cpp
+++ b/src/libmosqueeze/src/FileTypeDetector.cpp
@@ -253,6 +253,8 @@ FileClassification FileTypeDetector::detectFromExtension(const std::string& ext)
         {".arw", makeClassification(FileType::Image_Raw, "image/x-sony-arw", false, true, ".arw")},
         {".sr2", makeClassification(FileType::Image_Raw, "image/x-sony-sr2", false, true, ".sr2")},
         {".dng", makeClassification(FileType::Image_Raw, "image/x-adobe-dng", false, true, ".dng")},
+        {".iiq", makeClassification(FileType::Image_Raw, "image/x-phaseone-iiq", false, true, ".iiq")},
+        {".3fr", makeClassification(FileType::Image_Raw, "image/x-hasselblad-3fr", false, true, ".3fr")},
         {".orf", makeClassification(FileType::Image_Raw, "image/x-olympus-orf", false, true, ".orf")},
         {".rw2", makeClassification(FileType::Image_Raw, "image/x-panasonic-rw2", false, true, ".rw2")},
 

--- a/src/libmosqueeze/src/RawFormat.cpp
+++ b/src/libmosqueeze/src/RawFormat.cpp
@@ -1,0 +1,210 @@
+#include <mosqueeze/RawFormat.hpp>
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <string>
+
+namespace mosqueeze {
+namespace {
+
+bool hasPrefix(std::span<const uint8_t> data, std::span<const uint8_t> prefix) {
+    return data.size() >= prefix.size() &&
+        std::equal(prefix.begin(), prefix.end(), data.begin());
+}
+
+bool hasTiffHeader(std::span<const uint8_t> data) {
+    if (data.size() < 4) {
+        return false;
+    }
+    const bool le = (data[0] == 0x49 && data[1] == 0x49 && data[2] == 0x2A && data[3] == 0x00);
+    const bool be = (data[0] == 0x4D && data[1] == 0x4D && data[2] == 0x00 && data[3] == 0x2A);
+    return le || be;
+}
+
+std::string toUpper(std::string_view text) {
+    std::string out(text);
+    std::transform(out.begin(), out.end(), out.begin(), [](unsigned char c) {
+        return static_cast<char>(std::toupper(c));
+    });
+    return out;
+}
+
+RawFormatInfo makeFormat(
+    std::string_view extension,
+    std::string_view manufacturer,
+    RawCompression compression,
+    std::string_view compressionName,
+    bool isUncompressedAvailable,
+    std::string_view notes) {
+    return RawFormatInfo{
+        extension,
+        manufacturer,
+        compression,
+        compressionName,
+        isUncompressedAvailable,
+        notes
+    };
+}
+
+} // namespace
+
+std::optional<RawFormatInfo> RawFormatDetector::detect(std::span<const uint8_t> data) {
+    static constexpr std::array<uint8_t, 8> kRafMagic = {'F', 'U', 'J', 'I', 'F', 'I', 'L', 'M'};
+    static constexpr std::array<uint8_t, 4> kIiqMagic = {'I', 'I', 'Q', 0x00};
+    static constexpr std::array<uint8_t, 3> k3frMagicA = {'3', 'F', 'R'};
+    static constexpr std::array<uint8_t, 3> k3frMagicB = {'H', '3', 'D'};
+    static constexpr std::array<uint8_t, 8> kSonyMagic = {'S', 'O', 'N', 'Y', ' ', 'D', 'S', 'C'};
+
+    if (hasPrefix(data, kRafMagic)) {
+        RawCompression compression = RawCompression::Unknown;
+        std::string_view compressionName = "Unknown";
+        if (data.size() > 84) {
+            const uint8_t marker = data[84];
+            if (marker == 0) {
+                compression = RawCompression::Uncompressed;
+                compressionName = "Uncompressed RAW";
+            } else if (marker == 1) {
+                compression = RawCompression::LosslessCompressed;
+                compressionName = "Lossless Compressed RAW";
+            } else if (marker == 2) {
+                compression = RawCompression::LossyCompressed;
+                compressionName = "Lossy Compressed RAW";
+            }
+        }
+        return makeFormat(
+            ".RAF",
+            "Fujifilm",
+            compression,
+            compressionName,
+            true,
+            "Fujifilm default is often lossless compressed");
+    }
+
+    if (hasPrefix(data, kIiqMagic)) {
+        return makeFormat(
+            ".IIQ",
+            "Phase One",
+            RawCompression::Uncompressed,
+            "Uncompressed RAW",
+            true,
+            "Phase One IIQ is typically uncompressed");
+    }
+
+    if (hasPrefix(data, k3frMagicA) || hasPrefix(data, k3frMagicB)) {
+        return makeFormat(
+            ".3FR",
+            "Hasselblad",
+            RawCompression::Uncompressed,
+            "Uncompressed RAW",
+            true,
+            "Hasselblad 3FR is typically uncompressed");
+    }
+
+    if (hasPrefix(data, kSonyMagic)) {
+        return makeFormat(
+            ".ARW",
+            "Sony",
+            RawCompression::Unknown,
+            "Unknown",
+            true,
+            "Check camera setting for uncompressed RAW mode");
+    }
+
+    if (data.size() >= 12 && hasTiffHeader(data) && data[8] == 'C' && data[9] == 'R') {
+        return makeFormat(
+            ".CR2",
+            "Canon",
+            RawCompression::Unknown,
+            "Unknown",
+            true,
+            "CR2 can be compressed or uncompressed depending on camera setting");
+    }
+
+    if (data.size() >= 12 &&
+        data[4] == 'f' && data[5] == 't' && data[6] == 'y' && data[7] == 'p') {
+        return makeFormat(
+            ".CR3",
+            "Canon",
+            RawCompression::Unknown,
+            "Unknown",
+            true,
+            "CR3 tile compression depends on source settings");
+    }
+
+    return std::nullopt;
+}
+
+std::optional<RawFormatInfo> RawFormatDetector::detectByExtension(std::string_view filename) {
+    const size_t dot = filename.find_last_of('.');
+    if (dot == std::string_view::npos) {
+        return std::nullopt;
+    }
+    const std::string ext = toUpper(filename.substr(dot));
+    if (ext == ".RAF") {
+        return makeFormat(
+            ".RAF",
+            "Fujifilm",
+            RawCompression::LosslessCompressed,
+            "Lossless Compressed RAW (assumed)",
+            true,
+            "Most modern RAF files are lossless compressed by default");
+    }
+    if (ext == ".IIQ") {
+        return makeFormat(
+            ".IIQ",
+            "Phase One",
+            RawCompression::Uncompressed,
+            "Uncompressed RAW",
+            true,
+            "IIQ is usually uncompressed");
+    }
+    if (ext == ".3FR") {
+        return makeFormat(
+            ".3FR",
+            "Hasselblad",
+            RawCompression::Uncompressed,
+            "Uncompressed RAW",
+            true,
+            "3FR is usually uncompressed");
+    }
+    if (ext == ".ARW") {
+        return makeFormat(
+            ".ARW",
+            "Sony",
+            RawCompression::Unknown,
+            "Unknown",
+            true,
+            "May be compressed or uncompressed");
+    }
+    if (ext == ".NEF" || ext == ".NRW") {
+        return makeFormat(
+            ext == ".NEF" ? ".NEF" : ".NRW",
+            "Nikon",
+            RawCompression::Unknown,
+            "Unknown",
+            true,
+            "Nikon often uses lossless compressed RAW by default");
+    }
+    if (ext == ".CR2" || ext == ".CR3") {
+        return makeFormat(
+            ext == ".CR2" ? ".CR2" : ".CR3",
+            "Canon",
+            RawCompression::Unknown,
+            "Unknown",
+            true,
+            "Canon RAW compression depends on camera setting");
+    }
+    if (ext == ".DNG") {
+        return makeFormat(
+            ".DNG",
+            "Adobe",
+            RawCompression::Unknown,
+            "Depends on source",
+            true,
+            "DNG inherits compression characteristics from source");
+    }
+    return std::nullopt;
+}
+
+} // namespace mosqueeze

--- a/src/libmosqueeze/src/preprocessors/BayerPreprocessor.cpp
+++ b/src/libmosqueeze/src/preprocessors/BayerPreprocessor.cpp
@@ -1,4 +1,5 @@
 #include <mosqueeze/preprocessors/BayerPreprocessor.hpp>
+#include <mosqueeze/RawFormat.hpp>
 #include "RafParser.hpp"
 
 #include <iterator>
@@ -46,15 +47,52 @@ PreprocessResult BayerPreprocessor::preprocess(
     result.originalBytes = originalSize;
 
     const std::vector<uint8_t> fileData(raw.begin(), raw.end());
+    const auto detectedFormat = RawFormatDetector::detect(fileData);
+    if (detectedFormat.has_value()) {
+        if (detectedFormat->compression == RawCompression::LossyCompressed) {
+            throw std::runtime_error(
+                std::string("BayerPreprocessor rejected lossy RAW format: ") +
+                std::string(detectedFormat->manufacturer) + " " +
+                std::string(detectedFormat->extension));
+        }
+        if (detectedFormat->compression == RawCompression::LosslessCompressed && !forceProcess_) {
+            output.write(raw.data(), static_cast<std::streamsize>(raw.size()));
+            result.processedBytes = originalSize;
+            result.metadata = {0}; // version 0 = pass-through/no transform
+            return result;
+        }
+    }
+
     const RafMetadata rafMeta = RafParser::parse(fileData);
 
     if (!rafMeta.valid ||
         rafMeta.rawImageSize < 2 ||
         static_cast<uint64_t>(rafMeta.rawImageOffset) + static_cast<uint64_t>(rafMeta.rawImageSize) > originalSize ||
         originalSize > static_cast<size_t>(std::numeric_limits<uint32_t>::max())) {
-        output.write(raw.data(), static_cast<std::streamsize>(raw.size()));
-        result.processedBytes = originalSize;
-        result.metadata = {0}; // version 0 = pass-through/no transform
+        if (!forceProcess_) {
+            output.write(raw.data(), static_cast<std::streamsize>(raw.size()));
+            result.processedBytes = originalSize;
+            result.metadata = {0}; // version 0 = pass-through/no transform
+            return result;
+        }
+
+        // Fallback: full-payload reversible byte-plane transform.
+        const size_t words = originalSize / 2;
+        std::vector<uint8_t> transformed;
+        transformed.resize(originalSize);
+        for (size_t i = 0; i < words; ++i) {
+            transformed[i] = fileData[i * 2];
+            transformed[words + i] = fileData[(i * 2) + 1];
+        }
+        if ((originalSize % 2) != 0U) {
+            transformed[words * 2] = fileData[words * 2];
+        }
+
+        output.write(reinterpret_cast<const char*>(transformed.data()), static_cast<std::streamsize>(transformed.size()));
+        result.processedBytes = transformed.size();
+        result.metadata.reserve(5);
+        result.metadata.push_back(1); // version 1 = full payload transform
+        writeU32LE(result.metadata, static_cast<uint32_t>(originalSize));
         return result;
     }
 

--- a/src/mosqueeze-bench/src/BenchmarkRunner.cpp
+++ b/src/mosqueeze-bench/src/BenchmarkRunner.cpp
@@ -82,9 +82,9 @@ std::unordered_map<std::string, std::vector<int>> buildLevelMap(
     return levelsByAlgorithm;
 }
 
-std::unique_ptr<IPreprocessor> createPreprocessor(const std::string& name) {
+std::unique_ptr<IPreprocessor> createPreprocessor(const std::string& name, const BenchmarkConfig& config) {
     if (name == "bayer-raw") {
-        return std::make_unique<BayerPreprocessor>();
+        return std::make_unique<BayerPreprocessor>(config.forceBayer);
     }
     if (name == "image-meta-strip") {
         return std::make_unique<ImageMetaStripper>();
@@ -157,12 +157,17 @@ BenchmarkResult BenchmarkRunner::runIteration(
         preprocessMetrics.originalBytes = rawContent.size();
         preprocessMetrics.processedBytes = rawContent.size();
 
-        std::unique_ptr<IPreprocessor> selectedByName = createPreprocessor(config.preprocessMode);
+        std::unique_ptr<IPreprocessor> selectedByName = createPreprocessor(config.preprocessMode, config);
+        std::unique_ptr<IPreprocessor> selectedAutoOwned;
         std::unique_ptr<PreprocessorSelector> selector;
         IPreprocessor* preprocessor = nullptr;
         if (config.autoPreprocess()) {
             selector = std::make_unique<PreprocessorSelector>();
             preprocessor = selector->selectBest(fileType);
+            if (preprocessor != nullptr && preprocessor->name() == "bayer-raw") {
+                selectedAutoOwned = createPreprocessor("bayer-raw", config);
+                preprocessor = selectedAutoOwned.get();
+            }
         } else {
             preprocessor = selectedByName.get();
         }

--- a/src/mosqueeze-bench/src/main.cpp
+++ b/src/mosqueeze-bench/src/main.cpp
@@ -7,6 +7,7 @@
 #include <mosqueeze/engines/LzmaEngine.hpp>
 #include <mosqueeze/engines/ZpaqEngine.hpp>
 #include <mosqueeze/engines/ZstdEngine.hpp>
+#include <mosqueeze/RawFormat.hpp>
 
 #include <CLI/CLI.hpp>
 #include <nlohmann/json.hpp>
@@ -127,6 +128,63 @@ void dedupeFiles(std::vector<std::filesystem::path>& files) {
     std::sort(normalized.begin(), normalized.end());
     normalized.erase(std::unique(normalized.begin(), normalized.end()), normalized.end());
     files = std::move(normalized);
+}
+
+std::vector<uint8_t> readPrefix(const std::filesystem::path& file, size_t maxBytes) {
+    std::vector<uint8_t> buffer(maxBytes, 0);
+    std::ifstream in(file, std::ios::binary);
+    if (!in) {
+        return {};
+    }
+    in.read(reinterpret_cast<char*>(buffer.data()), static_cast<std::streamsize>(buffer.size()));
+    buffer.resize(static_cast<size_t>(in.gcount()));
+    return buffer;
+}
+
+std::string compressionToString(mosqueeze::RawCompression compression) {
+    switch (compression) {
+        case mosqueeze::RawCompression::Uncompressed:
+            return "uncompressed";
+        case mosqueeze::RawCompression::LosslessCompressed:
+            return "lossless-compressed";
+        case mosqueeze::RawCompression::LossyCompressed:
+            return "lossy-compressed";
+        case mosqueeze::RawCompression::Unknown:
+        default:
+            return "unknown";
+    }
+}
+
+void printRawDetectionDryRun(const std::vector<std::filesystem::path>& files, bool forceBayer) {
+    std::cout << "RAW format detection\n";
+    for (const auto& file : files) {
+        const auto prefix = readPrefix(file, 512);
+        auto detected = mosqueeze::RawFormatDetector::detect(prefix);
+        if (!detected.has_value()) {
+            detected = mosqueeze::RawFormatDetector::detectByExtension(file.filename().string());
+        }
+
+        if (!detected.has_value()) {
+            std::cout << "  " << file.string() << " -> unknown (bayer: "
+                      << (forceBayer ? "apply (forced)" : "skip by default")
+                      << ")\n";
+            continue;
+        }
+
+        const bool shouldApply = mosqueeze::RawFormatDetector::shouldApplyBayerPreprocessor(detected->compression);
+        std::string action = shouldApply ? "apply" : "skip";
+        if (!shouldApply && forceBayer && detected->compression != mosqueeze::RawCompression::LossyCompressed) {
+            action = "apply (forced)";
+        }
+        if (detected->compression == mosqueeze::RawCompression::LossyCompressed) {
+            action = "reject";
+        }
+
+        std::cout << "  " << file.string()
+                  << " -> " << detected->manufacturer << " " << detected->extension
+                  << " (" << compressionToString(detected->compression) << ")"
+                  << " | bayer: " << action << '\n';
+    }
 }
 
 struct ComparisonRow {
@@ -292,6 +350,7 @@ int main(int argc, char* argv[]) {
     int threadCount = 0;
     bool sequential = false;
     std::string preprocessMode = "none";
+    bool forceBayer = false;
 
     std::filesystem::path outputDir{"benchmarks/results"};
     std::filesystem::path exportFile;
@@ -337,6 +396,7 @@ int main(int argc, char* argv[]) {
            "Preprocessor mode: auto, none, bayer-raw, image-meta-strip, json-canonical, xml-canonical")
         ->check(CLI::IsMember({"auto", "none", "bayer-raw", "image-meta-strip", "json-canonical", "xml-canonical"}))
         ->default_val("none");
+    app.add_flag("--force-bayer", forceBayer, "Force Bayer preprocessing even when RAW appears compressed");
 
     app.add_option("-o,--output", outputDir, "Output directory");
     app.add_option("--export", exportFile, "Export results to file");
@@ -422,6 +482,7 @@ int main(int argc, char* argv[]) {
     config.threadCount = threadCount;
     config.sequential = sequential;
     config.preprocessMode = preprocessMode;
+    config.forceBayer = forceBayer;
 
     if (dryRun) {
         std::cout << "Configuration\n";
@@ -438,6 +499,10 @@ int main(int argc, char* argv[]) {
         std::cout << "  threadCount: " << config.threadCount << '\n';
         std::cout << "  sequential: " << (config.sequential ? "true" : "false") << '\n';
         std::cout << "  preprocess: " << config.preprocessMode << '\n';
+        std::cout << "  forceBayer: " << (config.forceBayer ? "true" : "false") << '\n';
+        if (config.preprocessMode == "bayer-raw" || config.preprocessMode == "auto") {
+            printRawDetectionDryRun(config.files, config.forceBayer);
+        }
         std::cout << "  effectiveThreads: " << config.getEffectiveThreadCount() << '\n';
         return 0;
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -117,6 +117,20 @@ add_custom_command(TARGET FileTypeDetector_test POST_BUILD
 
 add_test(NAME FileTypeDetector_test COMMAND FileTypeDetector_test)
 
+add_executable(RawFormat_test
+  unit/RawFormat_test.cpp
+)
+target_link_libraries(RawFormat_test
+  PRIVATE
+    libmosqueeze
+)
+add_custom_command(TARGET RawFormat_test POST_BUILD
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different
+          $<TARGET_FILE:libmosqueeze>
+          $<TARGET_FILE_DIR:RawFormat_test>
+)
+add_test(NAME RawFormat_test COMMAND RawFormat_test)
+
 add_executable(AlgorithmSelector_test
   unit/AlgorithmSelector_test.cpp
 )

--- a/tests/unit/BayerPreprocessor_test.cpp
+++ b/tests/unit/BayerPreprocessor_test.cpp
@@ -2,6 +2,7 @@
 
 #include <cassert>
 #include <cstdint>
+#include <exception>
 #include <iostream>
 #include <sstream>
 #include <string>
@@ -21,7 +22,7 @@ void writeLe32(std::vector<uint8_t>& data, size_t offset, uint32_t value) {
     data[offset + 3] = static_cast<uint8_t>((value >> 24U) & 0xFFU);
 }
 
-std::vector<uint8_t> makeSyntheticRaf(size_t& rawOffset, size_t& rawSize) {
+std::vector<uint8_t> makeSyntheticRaf(size_t& rawOffset, size_t& rawSize, uint8_t compressionMarker = 0) {
     constexpr size_t kSize = 0x240;
     constexpr size_t kTiffBase = 0x80;
     constexpr uint32_t kFirstIfd = 0x08;
@@ -34,6 +35,7 @@ std::vector<uint8_t> makeSyntheticRaf(size_t& rawOffset, size_t& rawSize) {
     for (size_t i = 0; i < 8; ++i) {
         data[i] = static_cast<uint8_t>(magic[i]);
     }
+    data[84] = compressionMarker;
 
     writeLe32(data, 0x34, static_cast<uint32_t>(kIfd));
     data[kTiffBase] = 0x49;
@@ -139,6 +141,51 @@ int main() {
     std::ostringstream restored;
     preprocessor.postprocess(transformedIn, restored, result);
     assert(restored.str() == original);
+
+    // Lossless-compressed RAF is skipped by default.
+    {
+        size_t losslessOffset = 0;
+        size_t losslessSize = 0;
+        const std::vector<uint8_t> losslessRaf = makeSyntheticRaf(losslessOffset, losslessSize, 1);
+        const std::string losslessText(reinterpret_cast<const char*>(losslessRaf.data()), losslessRaf.size());
+        std::istringstream losslessIn(losslessText);
+        std::ostringstream losslessOut;
+        const auto losslessResult = preprocessor.preprocess(losslessIn, losslessOut, mosqueeze::FileType::Image_Raw);
+        assert(losslessResult.metadata.size() == 1);
+        assert(losslessResult.metadata[0] == 0);
+        assert(losslessOut.str() == losslessText);
+    }
+
+    // Force mode allows processing lossless-compressed RAF.
+    {
+        mosqueeze::BayerPreprocessor forced(true);
+        size_t losslessOffset = 0;
+        size_t losslessSize = 0;
+        const std::vector<uint8_t> losslessRaf = makeSyntheticRaf(losslessOffset, losslessSize, 1);
+        const std::string losslessText(reinterpret_cast<const char*>(losslessRaf.data()), losslessRaf.size());
+        std::istringstream forcedIn(losslessText);
+        std::ostringstream forcedOut;
+        const auto forcedResult = forced.preprocess(forcedIn, forcedOut, mosqueeze::FileType::Image_Raw);
+        assert(forcedResult.metadata.size() == 13);
+        assert(forcedResult.metadata[0] == 2);
+    }
+
+    // Lossy-compressed RAF must be rejected.
+    {
+        bool threw = false;
+        try {
+            size_t lossyOffset = 0;
+            size_t lossySize = 0;
+            const std::vector<uint8_t> lossyRaf = makeSyntheticRaf(lossyOffset, lossySize, 2);
+            const std::string lossyText(reinterpret_cast<const char*>(lossyRaf.data()), lossyRaf.size());
+            std::istringstream lossyIn(lossyText);
+            std::ostringstream lossyOut;
+            (void)preprocessor.preprocess(lossyIn, lossyOut, mosqueeze::FileType::Image_Raw);
+        } catch (const std::exception&) {
+            threw = true;
+        }
+        assert(threw);
+    }
 
     const auto pattern = mosqueeze::BayerPreprocessor::detectPattern(nonRaf);
     assert(pattern == mosqueeze::BayerPattern::RGGB);

--- a/tests/unit/RawFormat_test.cpp
+++ b/tests/unit/RawFormat_test.cpp
@@ -1,0 +1,76 @@
+#include <mosqueeze/RawFormat.hpp>
+
+#include <cassert>
+#include <iostream>
+#include <vector>
+
+namespace {
+
+std::vector<uint8_t> makeRaf(uint8_t compressionMarker) {
+    std::vector<uint8_t> data(128, 0);
+    const char* magic = "FUJIFILM";
+    for (size_t i = 0; i < 8; ++i) {
+        data[i] = static_cast<uint8_t>(magic[i]);
+    }
+    data[84] = compressionMarker;
+    return data;
+}
+
+} // namespace
+
+int main() {
+    {
+        const auto rafLossless = makeRaf(1);
+        const auto detected = mosqueeze::RawFormatDetector::detect(rafLossless);
+        assert(detected.has_value());
+        assert(detected->extension == ".RAF");
+        assert(detected->compression == mosqueeze::RawCompression::LosslessCompressed);
+        assert(!mosqueeze::RawFormatDetector::shouldApplyBayerPreprocessor(detected->compression));
+    }
+
+    {
+        const auto rafUncompressed = makeRaf(0);
+        const auto detected = mosqueeze::RawFormatDetector::detect(rafUncompressed);
+        assert(detected.has_value());
+        assert(detected->compression == mosqueeze::RawCompression::Uncompressed);
+        assert(mosqueeze::RawFormatDetector::shouldApplyBayerPreprocessor(detected->compression));
+    }
+
+    {
+        const auto rafLossy = makeRaf(2);
+        const auto detected = mosqueeze::RawFormatDetector::detect(rafLossy);
+        assert(detected.has_value());
+        assert(detected->compression == mosqueeze::RawCompression::LossyCompressed);
+    }
+
+    {
+        std::vector<uint8_t> iiq = {'I', 'I', 'Q', 0x00, 0x01, 0x02, 0x03, 0x04};
+        const auto detected = mosqueeze::RawFormatDetector::detect(iiq);
+        assert(detected.has_value());
+        assert(detected->extension == ".IIQ");
+        assert(detected->compression == mosqueeze::RawCompression::Uncompressed);
+    }
+
+    {
+        const auto byExt = mosqueeze::RawFormatDetector::detectByExtension("sample.3fr");
+        assert(byExt.has_value());
+        assert(byExt->extension == ".3FR");
+        assert(byExt->compression == mosqueeze::RawCompression::Uncompressed);
+    }
+
+    {
+        const auto byExt = mosqueeze::RawFormatDetector::detectByExtension("sample.nef");
+        assert(byExt.has_value());
+        assert(byExt->extension == ".NEF");
+        assert(byExt->compression == mosqueeze::RawCompression::Unknown);
+    }
+
+    {
+        std::vector<uint8_t> unknown = {0x00, 0x01, 0x02, 0x03};
+        const auto detected = mosqueeze::RawFormatDetector::detect(unknown);
+        assert(!detected.has_value());
+    }
+
+    std::cout << "[PASS] RawFormat_test\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary
- classify RAW payloads before Bayer preprocessing and reject lossy formats
- skip lossless-compressed RAW by default, with `--force-bayer` to override
- add dry-run RAW classification output and document the workflow
- cover the new RAW detection and Bayer preprocessing behavior with unit tests

## Testing
- Added unit coverage for RAW format detection and Bayer preprocessing safety paths
- Updated benchmark documentation and wiki guides to reflect the new CLI behavior