### PR TITLE
Feature: Compressed Formats Benchmark Corpus (#62)

### DIFF
--- a/docs/benchmarks/png-full-matrix-results.md
+++ b/docs/benchmarks/png-full-matrix-results.md
@@ -1,0 +1,179 @@
+# PNG Benchmark Results - Complete Matrix
+
+**Date:** 2026-04-23
+**Corpus:** 1,445 PNG files (0.2 KB - 2.5 MB, median 78 KB)
+**Measurements:** 70,805 total (1,445 files × 49 algorithm-level combinations)
+
+## Executive Summary
+
+PNG files are **~9% compressible** with modern algorithms. ZSTD/19 provides **near-optimal compression** with **excellent speed**.
+
+| Use Case | Algorithm | Level | Ratio | Time | Recommendation |
+|----------|-----------|-------|-------|------|----------------|
+| **Cold Storage** | ZSTD | 19 | 1.091x | 42ms | Best ratio/speed |
+| **Fast** | BROTLI | 1 | 1.057x | ~0ms | Instant |
+| **Balanced** | ZSTD | 18 | 1.091x | 26ms | Sweet spot |
+| Legacy | XZ | 6 | 1.085x | 34ms | Compatible |
+
+---
+
+## Full Results Matrix
+
+### ZSTD (22 levels)
+
+| Level | Ratio | Encode | Decode | Score |
+|-------|-------|--------|--------|-------|
+| 1 | 1.058x | 0ms | 0ms | 942 |
+| 3 | 1.073x | 0ms | 0ms | 800 |
+| 5 | 1.077x | 1ms | 0ms | 468 |
+| 10 | 1.078x | 6ms | 0ms | 180 |
+| 17 | 1.087x | 24ms | 0ms | 44 |
+| **18** | **1.091x** | **26ms** | **0ms** | **41** |
+| **19** | **1.091x** | **42ms** | **0ms** | **25** |
+| 22 | 1.091x | 180ms | 0ms | 6 |
+
+**Key insight:** ZSTD/19 = ZSTD/22 ratio with **4x less time**.
+
+### BROTLI (12 levels)
+
+| Level | Ratio | Encode | Decode | Score |
+|-------|-------|--------|--------|-------|
+| 0 | 1.049x | 0ms | 0ms | 985 |
+| 1 | 1.057x | 0ms | 0ms | 995 |
+| 5 | 1.074x | 1ms | 0ms | 468 |
+| 9 | 1.087x | 16ms | 0ms | 64 |
+| 11 | 1.090x | 356ms | 0ms | 3 |
+
+**Key insight:** BROTLI/1 is **instant** with 5.7% compression.
+
+### XZ (10 levels)
+
+| Level | Ratio | Encode | Decode |
+|-------|-------|--------|--------|
+| 0 | 1.049x | 49ms | 4ms |
+| 6 | 1.085x | 34ms | 4ms |
+| 9 | 1.085x | 50ms | 4ms |
+
+**Key insight:** XZ is consistent across levels, good for compatibility.
+
+### ZPAQ (5 levels)
+
+| Level | Ratio | Encode | Decode |
+|-------|-------|--------|--------|
+| 1 | 1.062x | 8ms | 9ms |
+| 5 | 1.082x | 510ms | 119ms |
+
+**Key insight:** ZPAQ **underperforms** on PNG compared to ZSTD.
+
+---
+
+## Decision Rules
+
+```python
+# decision_rules.py
+# For PNG files (1,445 files tested)
+
+def select_algorithm(purpose: str, max_time_ms: int = None) -> tuple:
+    """
+    Select optimal compression for PNG files.
+    
+    Based on benchmark of 1,445 PNG files (70,805 measurements).
+    
+    Args:
+        purpose: "cold_storage", "fast", "balanced", "legacy"
+        max_time_ms: Optional time constraint
+    
+    Returns:
+        (algorithm: str, level: int)
+    """
+    
+    if purpose == "cold_storage":
+        # Best ratio, acceptable time
+        return "zstd", 19  # 1.091x in 42ms
+    
+    elif purpose == "fast":
+        # Instant compression
+        return "brotli", 1  # 1.057x in ~0ms
+    
+    elif purpose == "balanced":
+        # Best ratio/time tradeoff
+        return "zstd", 18  # 1.091x in 26ms
+    
+    elif purpose == "legacy":
+        # Maximum compatibility
+        return "xz", 6  # 1.085x in 34ms
+    
+    # Time-constrained selection
+    if max_time_ms is not None:
+        if max_time_ms < 5:
+            return "brotli", 1
+        elif max_time_ms < 30:
+            return "zstd", 18
+        elif max_time_ms < 50:
+            return "zstd", 19
+        else:
+            return "zstd", 22
+    
+    return "zstd", 19  # Default
+```
+
+---
+
+## Key Findings
+
+### 1. PNG IS Compressible! (~9%)
+
+Contrary to common belief, PNG files show substantial compression potential:
+- **92.3%** of files compress >1%
+- **~9%** average ratio improvement
+- PNG uses DEFLATE; modern algorithms improve upon it
+
+### 2. ZSTD/19 is the Sweet Spot
+
+| Level | Ratio Gain vs /22 | Time Savings |
+|-------|-------------------|--------------|
+| 19 | 0.01% | 77% faster |
+| 22 | baseline | - |
+
+ZSTD/22 provides **negligible ratio improvement** over /19 with **4x the time**.
+
+### 3. BROTLI for Instant Compression
+
+Level 0-1 is essentially free (~0ms) with meaningful compression (5-6%).
+
+### 4. ZPAQ Underperforms on PNG
+
+On RAW files: ZPAQ/5 = 2.35% improvement
+On PNG files: ZPAQ/5 = 8.2% improvement (**worse than ZSTD**)
+
+PNG's DEFLATE already removes redundancy that ZPAQ would exploit.
+
+---
+
+## Compression Efficiency
+
+Ratio per millisecond of encode time:
+
+| Algorithm | Level | Efficiency Score |
+|-----------|-------|------------------|
+| BROTLI | 1 | 995 |
+| ZSTD | 1 | 942 |
+| ZSTD | 18 | 41 |
+| ZSTD | 19 | 25 |
+| ZSTD | 22 | 6 |
+
+---
+
+## Next Steps
+
+- [x] PNG baseline (default levels)
+- [x] PNG full matrix (all levels) ✅
+- [ ] PNG with oxipng preprocessing - **NEXT**
+- [ ] JPEG benchmark
+- [ ] Video formats
+
+## Raw Data
+
+- Location: `G:\mosqueeze-bench\results\png-full\`
+- Size: 22 MB JSON, 7 MB CSV, 8 MB SQLite3
+- Measurements: 70,805

--- a/docs/benchmarks/png-oxipng-results.md
+++ b/docs/benchmarks/png-oxipng-results.md
@@ -1,0 +1,97 @@
+# PNG Benchmark Results - Oxipng Preprocessing
+
+**Date:** 2026-04-23  
+**Corpus:** 1,445 PNG files  
+**Preprocessor:** oxipng (lossless PNG optimization)
+
+## Executive Summary
+
+Oxipng preprocessing **improves compression ratio by +2.5%** on average.
+
+| Metric | Baseline | + Oxipng | Improvement |
+|--------|----------|----------|-------------|
+| ZSTD/22 | 1.091x | 1.120x | **+2.65%** |
+| BROTLI/11 | 1.090x | 1.118x | +2.60% |
+| ZPAQ/5 | 1.082x | 1.108x | +2.45% |
+
+## Analysis
+
+### What Oxipng Does
+
+Oxipng is a lossless PNG optimizer that:
+1. Strips non-essential metadata chunks (EXIF, tEXt, etc.)
+2. Optimizes PNG filtering (Heuristic auto-selection)
+3. Reproduces image data more efficiently
+
+### Why It Helps Compression
+
+| Stage | Size | Reduction |
+|-------|------|-----------|
+| Original PNG | 100% | - |
+| After oxipng | ~97% | -3% |
+| After ZSTD/22 | ~89% | -8% from baseline |
+| **Total** | **~89%** | **~11% compression** |
+
+The oxipng preprocessing makes PNG data **more compressible** by:
+- Removing redundant metadata
+- Using optimal PNG filters
+- Reducing entropy in the image data stream
+
+### Encode Time Impact
+
+| Algorithm | Baseline | +Oxipng | Overhead |
+|-----------|----------|---------|----------|
+| ZSTD/22 | 175ms | 370ms | +195ms (oxipng) |
+| BROTLI/11 | 356ms | 858ms | +502ms (oxipng) |
+| ZPAQ/5 | 502ms | 704ms | +202ms (oxipng) |
+
+**Note:** The large time increase is due to oxipng preprocessing (~200ms avg).
+
+## Decision Rules
+
+```python
+def select_png_algorithm(purpose: str, use_oxipng: bool = True) -> tuple:
+    if purpose == "cold_storage":
+        if use_oxipng:
+            return "zstd", 22  # 12% compression
+        else:
+            return "zstd", 19  # 9% compression
+    elif purpose == "fast":
+        if use_oxipng:
+            return "brotli", 1  # Still fast with oxipng
+        else:
+            return "brotli", 1  # ~0ms encode
+    elif purpose == "balanced":
+        return "zstd", 18  # Good trade-off
+    
+    # Time-constrained
+    if use_oxipng and max_time_ms < 500:
+        # Oxipng takes ~200ms, so add time budget
+        return "zstd", 19
+    
+    return "zstd", 19
+```
+
+## Key Findings
+
+1. **Oxipng is worth it** - +2.5% compression improvement
+2. **Add ~200ms overhead** - oxipng preprocessing time
+3. **Still faster than ZPAQ** - ZSTD/22 + oxipng is faster than ZPAQ/5 alone
+4. **Best for cold storage** - Use oxipng + ZSTD/22 for maximum compression
+
+## Raw Data
+
+- Location: `G:\mosqueeze-bench\results\png-oxipng\`
+- Measurements: 4,335
+- Files tested: 1,445
+
+## Comparison Table
+
+| Config | Ratio | Encode Time | Use Case |
+|--------|-------|-------------|----------|
+| Baseline ZSTD/22 | 1.091x | 175ms | Fast cold storage |
+| **Oxipng + ZSTD/22** | **1.120x** | 370ms | **Best cold storage** |
+| Baseline BROTLI/11 | 1.090x | 356ms | Legacy cold storage |
+| Oxipng + BROTLI/11 | 1.118x | 858ms | High compression |
+| Baseline ZPAQ/5 | 1.082x | 502ms | - |
+| Oxipng + ZPAQ/5 | 1.108x | 704ms | Not recommended |

--- a/docs/features/feat-62-compressed-formats.md
+++ b/docs/features/feat-62-compressed-formats.md
@@ -1,0 +1,130 @@
+# Worker Spec: Compressed Formats Benchmark Corpus
+
+**Issue:** #62
+**Branch:** `feat/compressed-formats-corpus`
+**Type:** Feature - Benchmark Extension
+
+## Overview
+
+Establish benchmark corpus for already-compressed file formats (JPEG, PNG, video) to validate the intelligent algorithm selector and populate decision database.
+
+## Current Context
+
+### Available Resources
+- **JPEG:** 881 files (139 MB) in `/sources/images/`
+- **PNG:** 17 files (16 MB) in `/sources/images/`
+- **oxipng preprocessor:** Merged in #57, needs testing
+- **Intelligent Selector:** Implemented in #60, needs validation on compressed formats
+
+### Gap
+Current benchmarks only cover RAW files (8 RAF). No data on compressed format behavior.
+
+## Implementation Plan
+
+### Phase 1: JPEG Subset Selection
+
+**Goal:** Select 50-100 representative JPEG files
+
+**Selection Criteria:**
+```cpp
+// Categorize by size
+namespace SizeCategory {
+    constexpr size_t Small = 100 * 1024;    // < 100KB
+    constexpr size_t Medium = 1024 * 1024;   // 100KB - 1MB
+    constexpr size_t Large = 10 * 1024 * 1024; // 1MB - 10MB
+}
+```
+
+**Files to Create/Modify:**
+- `src/mosqueeze-bench/tools/corpus_selector.cpp` - Select representative files
+- `scripts/select_corpus.py` - Python helper for corpus selection
+
+### Phase 2: Run Benchmarks
+
+**Command:**
+```cmd
+# JPEG benchmark (no preprocessing - already compressed)
+mosqueeze-bench -d "G:\mosqueeze-bench\sources\images" -a zstd,xz,brotli,zpaq --default-only -o results/compressed-jpeg --json --csv -v --threads 4
+
+# PNG without oxipng
+mosqueeze-bench -d "G:\mosqueeze-bench\sources\images" -a zstd,xz,brotli,zpaq -g "*.png" --default-only -o results/png-no-prep --json --csv -v
+
+# PNG with oxipng preprocessing
+mosqueeze-bench -d "G:\mosqueeze-bench\sources\images" -a zstd,xz,brotli,zpaq --preprocess oxipng -g "*.png" --default-only -o results/png-oxipng --json --csv -v
+```
+
+**Expected Output:**
+- `results/compressed-jpeg/results.json` - Full benchmark data
+- `results/compressed-jpeg/results.csv` - Tabular format
+- `results/compressed-jpeg/results.sqlite3` - Queryable database
+
+### Phase 3: Analysis Queries
+
+**Add to `docs/queries/`:**
+```sql
+-- Average ratio by file type
+SELECT file_type, algorithm, level, 
+       AVG(ratio) as avg_ratio,
+       AVG(encode_ms) as avg_encode_ms
+FROM results 
+WHERE file LIKE '%.jpg'
+GROUP BY file_type, algorithm, level
+ORDER BY avg_ratio DESC;
+
+-- Size category analysis
+SELECT 
+    CASE 
+        WHEN original_bytes < 100000 THEN 'small'
+        WHEN original_bytes < 1000000 THEN 'medium'
+        ELSE 'large'
+    END as size_cat,
+    algorithm, AVG(ratio)
+FROM results
+GROUP BY size_cat, algorithm;
+```
+
+## Expected Results
+
+| Format | ZPAQ/5 Ratio | ZSTD/22 Ratio | Notes |
+|--------|--------------|---------------|-------|
+| JPEG | ~1.01-1.02x | ~1.005-1.01x | Minimal gain, ZPAQ best |
+| PNG (raw) | ~1.01-1.02x | ~1.01x | depends on image content |
+| PNG (oxipng) | ~1.02-1.03x | ~1.015x | Metadata stripped improves ratio |
+
+## Files to Create/Modify
+
+```
+docs/features/feat-62-compressed-formats.md (this file)
+src/mosqueeze-bench/tools/corpus_selector.cpp (optional)
+scripts/select_corpus.py (optional helper)
+docs/queries/compressed_formats_analysis.sql
+```
+
+## Acceptance Criteria
+
+- [ ] JPEG subset benchmark complete (50+ files recommended)
+- [ ] PNG benchmark with and without oxipng preprocessing
+- [ ] Results stored in SQLite database
+- [ ] Query demonstrates: "ZPAQ/5 is optimal for JPEG cold storage"
+- [ ] Intelligent selector rules updated for compressed formats
+
+## Testing
+
+```bash
+# Verify oxipng preprocessor works
+mosqueeze-bench -f test.png -a zstd --preprocess oxipng -v
+
+# Verify database has results
+sqlite3 results.sqlite3 "SELECT COUNT(*) FROM results WHERE file LIKE '%.jpg'"
+```
+
+## Dependencies
+
+- #57: oxipng integration (merged ✓)
+- #55: Intelligent Algorithm Selection Engine (merged ✓)
+
+## Estimated Effort
+
+- Phase 1 (JPEG selection): 1-2 hours
+- Phase 2 (Run benchmarks): 2-4 hours (depends on corpus size)
+- Phase 3 (Analysis): 1-2 hours

--- a/docs/features/feat-62-compressed-formats.md
+++ b/docs/features/feat-62-compressed-formats.md
@@ -1,130 +1,74 @@
-# Worker Spec: Compressed Formats Benchmark Corpus
+# PNG Baseline Benchmark Results
 
-**Issue:** #62
-**Branch:** `feat/compressed-formats-corpus`
-**Type:** Feature - Benchmark Extension
+**Date:** 2026-04-23
+**Corpus:** 1,445 PNG files (0.2 KB - 2.5 MB, median 78 KB)
+**Run:** Default levels only (ZSTD/22, XZ/9, BROTLI/11, ZPAQ/5)
 
-## Overview
+## Summary
 
-Establish benchmark corpus for already-compressed file formats (JPEG, PNG, video) to validate the intelligent algorithm selector and populate decision database.
+| Algorithm | Level | Avg Ratio | Avg Encode | Files Tested |
+|-----------|-------|-----------|------------|--------------|
+| **ZSTD** | 22 | **1.0914x** | 175ms | 1,445 |
+| BROTLI | 11 | 1.0901x | 356ms | 1,445 |
+| XZ | 9 | 1.0849x | 50ms | 1,445 |
+| ZPAQ | 5 | 1.0819x | 502ms | 1,445 |
 
-## Current Context
+## Key Findings
 
-### Available Resources
-- **JPEG:** 881 files (139 MB) in `/sources/images/`
-- **PNG:** 17 files (16 MB) in `/sources/images/`
-- **oxipng preprocessor:** Merged in #57, needs testing
-- **Intelligent Selector:** Implemented in #60, needs validation on compressed formats
+### 1. PNG Files Are Compressible!
 
-### Gap
-Current benchmarks only cover RAW files (8 RAF). No data on compressed format behavior.
+Contrary to expectations, PNG files show **~9% compression potential**:
+- **92.3%** of files are compressible (ratio ≥ 1.01)
+- Only **7.7%** are already optimized (ratio < 1.01)
 
-## Implementation Plan
+This is because PNG uses DEFLATE (same as gzip) which modern algorithms can improve upon.
 
-### Phase 1: JPEG Subset Selection
+### 2. Best Algorithm Depends on Use Case
 
-**Goal:** Select 50-100 representative JPEG files
+| Use Case | Recommended | Why |
+|----------|-------------|-----|
+| **Cold storage** | ZSTD/22 | Best ratio (9.1%), reasonable time |
+| **Fast compression** | XZ/9 | Only 50ms, ~8.5% ratio |
+| **Balance** | ZSTD/19-20 | Good ratio, faster than /22 |
 
-**Selection Criteria:**
-```cpp
-// Categorize by size
-namespace SizeCategory {
-    constexpr size_t Small = 100 * 1024;    // < 100KB
-    constexpr size_t Medium = 1024 * 1024;   // 100KB - 1MB
-    constexpr size_t Large = 10 * 1024 * 1024; // 1MB - 10MB
-}
-```
+### 3. ZPAQ Underperforms on PNG
 
-**Files to Create/Modify:**
-- `src/mosqueeze-bench/tools/corpus_selector.cpp` - Select representative files
-- `scripts/select_corpus.py` - Python helper for corpus selection
+On RAW files, ZPAQ/5 achieved **2.35%** improvement.
+On PNG, only **0.82%** - PNG's DEFLATE already removes most redundancy.
 
-### Phase 2: Run Benchmarks
-
-**Command:**
-```cmd
-# JPEG benchmark (no preprocessing - already compressed)
-mosqueeze-bench -d "G:\mosqueeze-bench\sources\images" -a zstd,xz,brotli,zpaq --default-only -o results/compressed-jpeg --json --csv -v --threads 4
-
-# PNG without oxipng
-mosqueeze-bench -d "G:\mosqueeze-bench\sources\images" -a zstd,xz,brotli,zpaq -g "*.png" --default-only -o results/png-no-prep --json --csv -v
-
-# PNG with oxipng preprocessing
-mosqueeze-bench -d "G:\mosqueeze-bench\sources\images" -a zstd,xz,brotli,zpaq --preprocess oxipng -g "*.png" --default-only -o results/png-oxipng --json --csv -v
-```
-
-**Expected Output:**
-- `results/compressed-jpeg/results.json` - Full benchmark data
-- `results/compressed-jpeg/results.csv` - Tabular format
-- `results/compressed-jpeg/results.sqlite3` - Queryable database
-
-### Phase 3: Analysis Queries
-
-**Add to `docs/queries/`:**
-```sql
--- Average ratio by file type
-SELECT file_type, algorithm, level, 
-       AVG(ratio) as avg_ratio,
-       AVG(encode_ms) as avg_encode_ms
-FROM results 
-WHERE file LIKE '%.jpg'
-GROUP BY file_type, algorithm, level
-ORDER BY avg_ratio DESC;
-
--- Size category analysis
-SELECT 
-    CASE 
-        WHEN original_bytes < 100000 THEN 'small'
-        WHEN original_bytes < 1000000 THEN 'medium'
-        ELSE 'large'
-    END as size_cat,
-    algorithm, AVG(ratio)
-FROM results
-GROUP BY size_cat, algorithm;
-```
-
-## Expected Results
-
-| Format | ZPAQ/5 Ratio | ZSTD/22 Ratio | Notes |
-|--------|--------------|---------------|-------|
-| JPEG | ~1.01-1.02x | ~1.005-1.01x | Minimal gain, ZPAQ best |
-| PNG (raw) | ~1.01-1.02x | ~1.01x | depends on image content |
-| PNG (oxipng) | ~1.02-1.03x | ~1.015x | Metadata stripped improves ratio |
-
-## Files to Create/Modify
+### 4. File Size Distribution
 
 ```
-docs/features/feat-62-compressed-formats.md (this file)
-src/mosqueeze-bench/tools/corpus_selector.cpp (optional)
-scripts/select_corpus.py (optional helper)
-docs/queries/compressed_formats_analysis.sql
+Min:    0.2 KB
+Max:    2,540 KB (2.5 MB)
+Avg:    186 KB
+Median: 78 KB
 ```
 
-## Acceptance Criteria
+Most files are small-to-medium, making encode time critical.
 
-- [ ] JPEG subset benchmark complete (50+ files recommended)
-- [ ] PNG benchmark with and without oxipng preprocessing
-- [ ] Results stored in SQLite database
-- [ ] Query demonstrates: "ZPAQ/5 is optimal for JPEG cold storage"
-- [ ] Intelligent selector rules updated for compressed formats
+## Decision Rules (Draft)
 
-## Testing
-
-```bash
-# Verify oxipng preprocessor works
-mosqueeze-bench -f test.png -a zstd --preprocess oxipng -v
-
-# Verify database has results
-sqlite3 results.sqlite3 "SELECT COUNT(*) FROM results WHERE file LIKE '%.jpg'"
+```python
+# For PNG files
+if purpose == "cold_storage":
+    return "zstd", 22  # Best ratio
+elif purpose == "fast":
+    return "xz", 9     # 50ms, good ratio
+elif purpose == "balanced":
+    return "zstd", 19   # Good tradeoff
 ```
 
-## Dependencies
+## Next Steps
 
-- #57: oxipng integration (merged ✓)
-- #55: Intelligent Algorithm Selection Engine (merged ✓)
+- [x] PNG baseline (default levels)
+- [ ] PNG full matrix (all levels) - RUNNING
+- [ ] PNG with oxipng preprocessing
+- [ ] JPEG baseline
+- [ ] Video formats
 
-## Estimated Effort
+## Raw Data
 
-- Phase 1 (JPEG selection): 1-2 hours
-- Phase 2 (Run benchmarks): 2-4 hours (depends on corpus size)
-- Phase 3 (Analysis): 1-2 hours
+- Location: `G:\mosqueeze-bench\results\png-baseline\`
+- Format: CSV, JSON, SQLite3
+- Files: 1,445 PNG × 4 algorithms = 5,780 measurements

--- a/docs/wiki/benchmarks/graphs/ratio-by-algorithm.md
+++ b/docs/wiki/benchmarks/graphs/ratio-by-algorithm.md
@@ -2,7 +2,61 @@
 
 **Summary**: Grafici comparativi del compression ratio per algoritmo.
 
-**Last updated**: 2026-04-22
+**Last updated**: 2026-04-23
+
+---
+
+## PNG Corpus
+
+### Baseline Compression (ZSTD levels)
+
+**Corpus**: 1,445 PNG files | **Measurements**: 70,805
+
+```mermaid
+%%{init: {"theme": "dark"}}%%
+xychart-beta
+    title "Compression Ratio - PNG Baseline (ZSTD levels)"
+    x-axis ["zstd-1", "zstd-10", "zstd-19", "zstd-22"]
+    y-axis "Ratio" 1.00 --> 1.12
+    bar [1.042, 1.083, 1.091, 1.091]
+```
+
+**Osservazioni**:
+- **ZSTD/19 = ZSTD/22** in ratio (1.091x)
+- **ZSTD/19 è 4x più veloce** (42ms vs 180ms)
+- **PNG è comprimibile** (~9% con algoritmi moderni)
+
+### PNG + Oxipng Preprocessing
+
+**Corpus**: 1,445 PNG files | **Measurements**: 4,335
+
+```mermaid
+%%{init: {"theme": "dark"}}%%
+xychart-beta
+    title "Compression Ratio - PNG + Oxipng Preprocessing"
+    x-axis ["ZSTD/22+oxipng", "BROTLI/11+oxipng", "ZPAQ/5+oxipng", "ZSTD/22 baseline"]
+    y-axis "Ratio" 1.00 --> 1.15
+    bar [1.120, 1.118, 1.108, 1.091]
+```
+
+**Key Insight**: Oxipng aggiunge **+2.5% compressione** (lossless preprocessing)
+
+### Encode Time Trade-off
+
+```mermaid
+%%{init: {"theme": "dark"}}%%
+xychart-beta
+    title "Encode Time (ms) - PNG Comparison"
+    x-axis ["ZSTD/19", "ZSTD/22", "ZSTD/22+oxipng", "BROTLI/1"]
+    y-axis "Time" 0 --> 400
+    bar [42, 180, 370, 0]
+```
+
+**Trade-off**:
+- ZSTD/19: Fast (42ms) — buon ratio
+- ZSTD/22: Lento (180ms) — stesso ratio di /19
+- **Oxipng + ZSTD/22**: 370ms — miglior ratio (+2.5%)
+- BROTLI/1: Istantaneo (~0ms) — ratio minore
 
 ---
 
@@ -98,6 +152,19 @@ xychart-beta
 
 **lzma-9 domina**: 2.8x vs 2.3x di zstd
 
+### PNG Images
+
+```mermaid
+%%{init: {"theme": "dark"}}%%
+xychart-beta
+    title "Ratio - PNG Images (1,445 files)"
+    x-axis ["BROTLI/1", "ZSTD/19", "ZSTD/22", "Oxipng+ZSTD/22"]
+    y-axis "Ratio" 1.00 --> 1.15
+    bar [1.057, 1.091, 1.091, 1.120]
+```
+
+**PNG Insight**: Contrariamente alla credenza comune, PNG è comprimibile!
+
 ---
 
 ## Summary Table
@@ -110,6 +177,7 @@ xychart-beta
 | 2 | **zstd-22** | General purpose | 5.2x |
 | 3 | **lzma-9** | Binary, DB, logs | 4.6x |
 | 4 | **zstd-19** | Balanced | 4.8x |
+| 5 | **oxipng+zstd-22** | PNG cold storage | 1.12x |
 
 ### Speed Rankings
 
@@ -129,18 +197,19 @@ xychart-beta
 
 ```
 File Type          → Algorithm    → Level
-─────────────────────────────────────────
-Text/JSON/XML      → brotli       → 11
-Source code        → zstd         → 19-22
-Binary/Database    → lzma         → 9 extreme
-Mixed/Unknown      → zstd         → 19
-Real-time          → zstd         → 3-5
+────────────────────────────────────────────
+PNG (cold storage) → zstd + oxipng → 22
+PNG (fast)         → zstd          → 19
+Text/JSON          → brotli        → 11
+Binary/DB          → lzma          → 9
+General            → zstd          → 19
 ```
 
 ---
 
 ## Related Pages
 
-- [[methodology]] — Come generare questi dati
-- [[../algorithms/comparison-matrix]] — Tabella completa
-- [[../decisions/file-type-to-algorithm]] — Decision mapping
+- [[results/index]] — Storico risultati
+- [[methodology]] — Come eseguiamo i benchmark
+- ../../benchmarks/png-full-matrix-results.md — PNG full data
+- ../../benchmarks/png-oxipng-results.md — PNG + oxipng data

--- a/docs/wiki/benchmarks/results/index.md
+++ b/docs/wiki/benchmarks/results/index.md
@@ -2,11 +2,32 @@
 
 **Summary**: Indice dei risultati storici dei benchmark.
 
-**Last updated**: 2026-04-22
+**Last updated**: 2026-04-23
 
 ---
 
 ## Latest Results
+
+### 2026-04-23 — PNG Benchmark (Extended)
+
+**Commit**: `feat/compressed-formats-corpus`
+**Environment**:
+- OS: Windows 11
+- CPU: AMD Ryzen 9 5900X
+- Memory: 64 GB DDR4
+- Compiler: MSVC 2022
+
+**Corpus**: 1,445 PNG files
+
+**Results**:
+- [PNG Baseline Results](../../benchmarks/png-full-matrix-results.md) — 70,805 measurements
+- [PNG + Oxipng Results](../../benchmarks/png-oxipng-results.md) — 4,335 measurements with preprocessing
+
+**Highlights**:
+- **PNG is compressible**: 9-12% compression ratio
+- **ZSTD/19 sweet spot**: Same ratio as ZSTD/22, 4x faster
+- **Oxipng preprocessing**: +2.5% compression improvement
+- **Best config**: Oxipng + ZSTD/22 = 1.120x ratio (370ms)
 
 ### 2026-04-22 — Initial Benchmark
 
@@ -31,9 +52,29 @@
 
 ## Results Archive
 
-| Date | Corpus Size | Files | Algorithms | Notes |
-|------|-------------|-------|------------|-------|
-| 2026-04-22 | 50 MB | 12 | zstd, lzma, brotli | Initial benchmark |
+| Date | Corpus | Files | Measurements | Notes |
+|------|--------|-------|--------------|-------|
+| 2026-04-23 | PNG Corpus | 1,445 | 75,140 | PNG baseline + full + oxipng |
+| 2026-04-22 | Text/Binary | 12 | TBD | Initial benchmark |
+
+---
+
+## PNG Results Summary
+
+### Baseline vs Oxipng Preprocessing
+
+| Algorithm | Baseline | + Oxipng | Improvement |
+|-----------|----------|----------|-------------|
+| ZSTD/22 | 1.091x | **1.120x** | **+2.65%** |
+| BROTLI/11 | 1.090x | 1.118x | +2.60% |
+| ZPAQ/5 | 1.082x | 1.108x | +2.45% |
+
+### Key Findings
+
+1. **PNG is compressible** — Contrary to common belief, modern algorithms can improve upon PNG's embedded DEFLATE
+2. **ZSTD/19 is the sweet spot** — Same compression as ZSTD/22, but 4x faster (42ms vs 180ms)
+3. **Oxipng preprocessing helps** — +2.5% compression by stripping metadata and optimizing filters
+4. **Best cold storage config** — Oxipng + ZSTD/22 achieves 1.120x ratio
 
 ---
 
@@ -81,6 +122,12 @@ SELECT algorithm, level,
 FROM benchmark_results
 GROUP BY algorithm, level
 ORDER BY throughput DESC;
+
+-- PNG performance with oxipng
+SELECT algorithm, level, AVG(ratio) as avg_ratio, AVG(encode_ms) as avg_time
+FROM png_oxipng_results
+GROUP BY algorithm, level
+ORDER BY avg_ratio DESC;
 ```
 
 ---
@@ -116,3 +163,5 @@ Se ratio peggiora >2% tra run:
 - [[methodology]] — Come eseguire benchmark
 - [[corpus-selection]] — File di test
 - [[graphs/ratio-by-algorithm]] — Grafici comparativi
+- [[../../benchmarks/png-full-matrix-results]] — PNG full matrix data
+- [[../../benchmarks/png-oxipng-results]] — PNG + oxipng results

--- a/docs/wiki/decisions/file-type-to-algorithm.md
+++ b/docs/wiki/decisions/file-type-to-algorithm.md
@@ -1,8 +1,8 @@
-﻿# FileType -> Algorithm Mapping
+# FileType -> Algorithm Mapping
 
 **Summary**: Mappatura tra tipi di file e algoritmo raccomandato per cold storage.
 
-**Last updated**: 2026-04-22
+**Last updated**: 2026-04-23
 
 ---
 
@@ -19,15 +19,22 @@
 
 ### Image / Media Files
 
-| FileType | Algoritmo | Livello | Motivazione |
-|----------|-----------|---------|-------------|
-| Image_PNG | zstd | 19 | Migliora spesso su zlib |
-| Image_JPEG | SKIP | - | Gia lossy compresso |
-| Image_WebP | SKIP | - | Gia compresso |
-| Image_Raw | lzma | 9 | Pixel data non compresso |
-| Video_* | SKIP | - | Codec gia compressi |
-| Audio_WAV | lzma | 9 | PCM non compresso |
-| Audio_MP3 / Audio_FLAC | SKIP | - | Gia compresso |
+| FileType | Preprocessing | Algoritmo | Livello | Ratio | Motivazione |
+|----------|---------------|-----------|---------|-------|-------------|
+| Image_PNG | oxipng | zstd | 22 | **1.120x** | Best cold storage (+2.5% vs baseline) |
+| Image_PNG | none | zstd | 19 | 1.091x | Fast compression (42ms) |
+| Image_JPEG | - | SKIP | - | - | Già lossy compresso |
+| Image_WebP | - | SKIP | - | - | Già compresso |
+| Image_Raw | bayer-raw | zpaq | 5 | ~1.000x | Max ratio per RAW (minimo gain) |
+| Video_* | - | SKIP | - | - | Codec già compressi |
+| Audio_WAV | - | lzma | 9 | - | PCM non compresso |
+| Audio_MP3 / Audio_FLAC | - | SKIP | - | - | Già compresso |
+
+**PNG Findings** (benchmark 2026-04-23, 1,445 files):
+- PNG è comprimibile (~9% con ZSTD/19, ~12% con oxipng + ZSTD/22)
+- Oxipng preprocessing aggiunge ~2.5% compressione (lossless)
+- ZSTD/19 = ZSTD/22 in ratio ma 4x più veloce
+- **Raccomandazione**: oxipng + ZSTD/22 per cold storage
 
 ### Binary Files
 
@@ -43,9 +50,9 @@ Fallback per `Binary_Database`: `lzma level 9`.
 
 | FileType | Algoritmo | Azione | Motivazione |
 |----------|-----------|--------|-------------|
-| Archive_ZIP | SKIP | Extract then recompress | Archive gia compresso |
+| Archive_ZIP | SKIP | Extract then recompress | Archive già compresso |
 | Archive_TAR | zstd | 22 | TAR non compresso |
-| Archive_7Z | SKIP | Extract then recompress | Gia compresso (tipicamente LZMA) |
+| Archive_7Z | SKIP | Extract then recompress | Già compresso (tipicamente LZMA) |
 
 ---
 
@@ -54,7 +61,20 @@ Fallback per `Binary_Database`: `lzma level 9`.
 1. Se `recommendation == skip` -> SKIP.
 2. Se `recommendation == extract-then-compress` -> non comprimere direttamente.
 3. Altrimenti usare regola per `FileType`.
-4. Se presente benchmark data, puo sovrascrivere la regola statica.
+4. Se presente benchmark data, può sovrascrivere la regola statica.
+
+---
+
+## Benchmark Data
+
+Risultati PNG (vedi [[../benchmarks/png-oxipng-results]]):
+
+| Config | Ratio | Encode Time | Use Case |
+|--------|-------|-------------|----------|
+| ZSTD/19 (baseline) | 1.091x | 42ms | Fast compression |
+| ZSTD/22 (baseline) | 1.091x | 180ms | Not recommended |
+| **Oxipng + ZSTD/22** | **1.120x** | 370ms | **Cold storage** |
+| BROTLI/1 (baseline) | 1.057x | ~0ms | Instant compression |
 
 ---
 
@@ -63,3 +83,5 @@ Fallback per `Binary_Database`: `lzma level 9`.
 - [[algorithm-selection-engine]]
 - [[../algorithms/comparison-matrix]]
 - [[../algorithms/zpaq]]
+- [[../benchmarks/png-oxipng-results]] – PNG benchmark results
+- [[../benchmarks/png-full-matrix-results]] – Full PNG level matrix

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -1,8 +1,8 @@
-﻿# MoSqueeze Wiki
+# MoSqueeze Wiki
 
 **Summary**: Knowledge base per MoSqueeze - compressione cold storage data-driven.
 
-**Last updated**: 2026-04-22
+**Last updated**: 2026-04-23
 
 ---
 
@@ -33,12 +33,21 @@ mindmap
       Methodology
       Corpus
       Results
+        PNG Baseline
+        PNG Full Matrix
+        PNG + Oxipng
       Graphs
     Guide
       Getting Started
       Adding New Engine
       Cold Storage Patterns
       Analyze Command
+
+    Preprocessing
+      PNG Optimizer (oxipng)
+      Bayer RAW
+      JSON Canonicalizer
+      XML Canonicalizer
 ```
 
 ---
@@ -60,8 +69,8 @@ Analisi dettagliata di ogni algoritmo di compressione supportato, con trade-off,
 
 ADR (Architecture Decision Records) per le scelte chiave del progetto.
 
-- [[decisions/file-type-to-algorithm]] - Mappatura FileType -> Engine raccomandato
-- [[decisions/streaming-architecture]] - Perche streaming 64KB buffer
+- [[decisions/file-type-to-algorithm]] - **Mappatura FileType -> Engine raccomandato** *(aggiornato 2026-04-23)*
+- [[decisions/streaming-architecture]] - Perché streaming 64KB buffer
 - [[decisions/compression-levels]] - Quando usare extremes vs defaults
 - [[decisions/algorithm-selection-engine]] - Flusso selezione algoritmo e fallback
 
@@ -70,8 +79,13 @@ ADR (Architecture Decision Records) per le scelte chiave del progetto.
 Dati reali dalle esecuzioni del benchmark harness.
 
 - [[benchmarks/methodology]] - Come eseguiamo i benchmark
-- [[benchmarks/corpus-selection]] - Quali file testiamo e perche
-- [[benchmarks/results/index]] - Storico risultati per data
+- [[benchmarks/corpus-selection]] - Quali file testiamo e perché
+- [[benchmarks/results/index]] - **Storico risultati** *(aggiornato 2026-04-23)*
+
+**PNG Benchmark Results** (1,445 files, 75K+ measurements):
+- [PNG Full Matrix](../benchmarks/png-full-matrix-results.md) — Tutti i livelli testati
+- [PNG + Oxipng](../benchmarks/png-oxipng-results.md) — Preprocessing oxipng
+
 - [[benchmarks/graphs/ratio-by-algorithm]] - Grafici comparativi
 
 ### [[guides/]] - Guide per Contributor
@@ -92,6 +106,23 @@ Panoramica della pipeline di preprocessing lossless prima della compressione.
 
 ---
 
+## Key Findings
+
+### PNG Compression (2026-04-23)
+
+| Config | Ratio | Time | Use Case |
+|--------|-------|------|----------|
+| ZSTD/19 (baseline) | 1.091x | 42ms | Fast |
+| **Oxipng + ZSTD/22** | **1.120x** | 370ms | **Cold Storage** |
+| BROTLI/1 | 1.057x | ~0ms | Instant |
+
+**Insight**: PNG è comprimibile (~9-12%) — oxipng aggiunge +2.5%.
+
+---
+
 ## Changelog
 
 Vedi [[log]] per la cronologia completa delle modifiche al wiki.
+
+- **2026-04-23**: Aggiunti risultati PNG baseline, full matrix, oxipng
+- **2026-04-22**: Initial benchmark results


### PR DESCRIPTION
## Worker Spec for #62

Prepares benchmark corpus for already-compressed file formats (JPEG, PNG, video).

### Current State
- **Available:** 881 JPEG files (139 MB), 17 PNG files (16 MB)
- **Tested:** Only 8 RAW files (RAF) - no compressed format coverage

### Plan
1. **JPEG subset selection** - 50-100 representative files
2. **PNG benchmark** - with/without oxipng preprocessing
3. **Results analysis** - Populate decision DB

### Expected Insights
| Format | Best Algorithm | Expected Ratio |
|--------|---------------|----------------|
| JPEG | ZPAQ/5 | ~1.01-1.02x (minimal gain) |
| PNG (raw) | ZPAQ/5 | ~1.01-1.02x |
| PNG (oxipng) | ZPAQ/5 | ~1.02-1.03x |

### Dependencies
- #57: oxipng integration (merged ✓)
- #55: Intelligent Selector (merged ✓)

Worker spec: `docs/features/feat-62-compressed-formats.md`