### PR TITLE
Fix: Progress bar duplication during long runs (#64)

### DIFF
--- a/docs/features/fix-64-progress-bar.md
+++ b/docs/features/fix-64-progress-bar.md
@@ -1,0 +1,137 @@
+# Worker Spec: Fix Progress Bar Duplication
+
+**Issue:** #64
+**Branch:** `fix/progress-bar-duplication`
+**Type:** Bug Fix - UI/UX
+
+## Problem
+
+Progress bar works correctly for first few minutes, then starts duplicating on new lines instead of updating in-place.
+
+## Root Cause Analysis
+
+### Possible Causes
+
+1. **Thread race condition** - Multiple worker threads calling progress callback simultaneously
+
+2. **Windows CMD buffer limit** - Terminal buffer overflow after many updates
+
+3. **`` handling** - Carriage return not clearing line properly:
+   ```cpp
+   // Current: may not clear entire line
+   std::cout << "\r" << progress_bar << std::flush;
+   
+   // Should clear to end of line
+   std::cout << "\r" << progress_bar << "\033[K" << std::flush;
+   ```
+
+4. **Progress callback mutex regression** - #50 fixed mutex bug but may have regressed
+
+## Files to Investigate
+
+```
+src/mosqueeze-bench/src/main.cpp         - Progress callback (line ~435)
+src/mosqueeze-bench/src/BenchmarkRunner.cpp - Progress reporting
+src/libmosqueeze/src/util/Progress.hpp   - Progress class
+```
+
+## Implementation
+
+### Step 1: Add Mutex to Progress Callback
+
+```cpp
+// src/mosqueeze-bench/src/main.cpp
+
+// BEFORE (buggy):
+if (verbose) {
+    auto progressMutex = std::make_shared<std::mutex>();
+    config.onProgress = [&](const ProgressInfo& info) {
+        std::lock_guard<std::mutex> lock(*progressMutex);
+        // ... progress output ...
+    };
+}
+
+// AFTER (fixed):
+if (verbose) {
+    auto progressMutex = std::make_shared<std::mutex>();
+    auto lastUpdate = std::make_shared<std::chrono::steady_clock::time_point>(
+        std::chrono::steady_clock::now()
+    );
+    
+    config.onProgress = [progressMutex, lastUpdate](const ProgressInfo& info) {
+        std::lock_guard<std::mutex> lock(*progressMutex);
+        
+        // Throttle updates to max 10 Hz
+        auto now = std::chrono::steady_clock::now();
+        auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(now - *lastUpdate).count();
+        if (elapsed < 100 && info.percent < 100) return;
+        *lastUpdate = now;
+        
+        // Clear line and print progress
+        std::cout << "\r\033[K" << formatProgress(info) << std::flush;
+    };
+}
+```
+
+### Step 2: Use ANSI Escape Codes for Windows
+
+Windows 10+ supports ANSI escape codes. Enable them:
+
+```cpp
+// At program start (main.cpp)
+#ifdef _WIN32
+    HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
+    DWORD dwMode = 0;
+    GetConsoleMode(hOut, &dwMode);
+    dwMode |= ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+    SetConsoleMode(hOut, dwMode);
+#endif
+```
+
+### Step 3: Alternative - Use Indicators Library
+
+Consider using a proper progress bar library:
+
+```cpp
+// Optional: use indicators for robust progress bars
+#include <indicators/progress_bar.hpp>
+
+indicators::ProgressBar bar{
+    indicators::option::BarWidth{50},
+    indicators::option::Fill{"█"},
+    indicators::option::Lead{"█"},
+    indicators::option::Remainder{"░"},
+};
+```
+
+## Testing
+
+```bash
+# Run with progress bar
+mosqueeze-bench -d "G:\mosqueeze-bench\sources\png" -a zstd --default-only -v
+
+# Run without progress bar (control)
+mosqueeze-bench -d "G:\mosqueeze-bench\sources\png" -a zstd --default-only --quiet
+
+# Long run to test durability
+mosqueeze-bench -d "large_corpus" -a zstd,brotli,zpaq -v
+```
+
+## Acceptance Criteria
+
+- [ ] Progress bar stays in place for runs >30 minutes
+- [ ] No duplication on new lines
+- [ ] Works on Windows CMD and PowerShell
+- [ ] Works with `--threads 4`
+- [ ] Progress bar clears properly at 100%
+
+## Related Issues
+
+- #50: Progress bar freeze (mutex fix)
+- #58: Preprocessor test coverage
+
+## Estimated Effort
+
+- Investigation: 1-2 hours
+- Implementation: 2-3 hours
+- Testing: 1 hour

--- a/src/mosqueeze-bench/include/mosqueeze/bench/ProgressReporter.hpp
+++ b/src/mosqueeze-bench/include/mosqueeze/bench/ProgressReporter.hpp
@@ -24,6 +24,9 @@ private:
     std::string buildLine() const;
     std::string formatEta(std::chrono::seconds remaining) const;
     std::string shortenFile(const std::string& file) const;
+    std::string fitToTerminalWidth(std::string line) const;
+    size_t detectTerminalWidth() const;
+    bool detectAnsiSupport() const;
 
     size_t totalFiles_ = 0;
     std::atomic<size_t> completedFiles_{0};
@@ -36,6 +39,8 @@ private:
 
     bool verbose_ = false;
     bool quiet_ = false;
+    bool ansiEnabled_ = false;
+    size_t terminalWidth_ = 0;
     bool printedLine_ = false;
     size_t lastLineLength_ = 0;
     mutable size_t spinnerIndex_ = 0;

--- a/src/mosqueeze-bench/src/ProgressReporter.cpp
+++ b/src/mosqueeze-bench/src/ProgressReporter.cpp
@@ -1,9 +1,20 @@
 #include <mosqueeze/bench/ProgressReporter.hpp>
 
 #include <algorithm>
+#include <cstdlib>
 #include <iomanip>
 #include <iostream>
 #include <sstream>
+
+#ifdef _WIN32
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#else
+#include <sys/ioctl.h>
+#include <unistd.h>
+#endif
 
 namespace mosqueeze::bench {
 namespace {
@@ -16,6 +27,8 @@ ProgressReporter::ProgressReporter(size_t totalFiles, bool verbose, bool quiet)
     : totalFiles_(totalFiles), verbose_(verbose), quiet_(quiet) {
     startTime_ = std::chrono::steady_clock::now();
     lastActivity_ = startTime_;
+    ansiEnabled_ = detectAnsiSupport();
+    terminalWidth_ = detectTerminalWidth();
     if (!quiet_ && totalFiles_ > 0) {
         renderThread_ = std::thread([this]() {
             std::unique_lock<std::mutex> lock(mutex_);
@@ -105,14 +118,18 @@ void ProgressReporter::updateDisplay(bool force) {
         return;
     }
 
-    std::string line = buildLine();
-    if (line.size() < lastLineLength_) {
+    std::string line = fitToTerminalWidth(buildLine());
+    if (!ansiEnabled_ && line.size() < lastLineLength_) {
         line.append(lastLineLength_ - line.size(), ' ');
     }
     lastLineLength_ = line.size();
     lastRender_ = now;
     printedLine_ = true;
-    std::cout << '\r' << line << std::flush;
+    if (ansiEnabled_) {
+        std::cout << "\r\x1b[2K" << line << std::flush;
+    } else {
+        std::cout << '\r' << line << std::flush;
+    }
 }
 
 std::string ProgressReporter::buildLine() const {
@@ -181,6 +198,74 @@ std::string ProgressReporter::shortenFile(const std::string& file) const {
         return file;
     }
     return file.substr(0, kMax - 3) + "...";
+}
+
+std::string ProgressReporter::fitToTerminalWidth(std::string line) const {
+    // Reserve one column to avoid implicit terminal wrapping that can create
+    // duplicated progress rows when repeatedly writing '\r' updates.
+    if (terminalWidth_ == 0 || terminalWidth_ <= 8) {
+        return line;
+    }
+    const size_t maxVisible = terminalWidth_ - 1;
+    if (line.size() <= maxVisible) {
+        return line;
+    }
+    if (maxVisible <= 3) {
+        return line.substr(0, maxVisible);
+    }
+    return line.substr(0, maxVisible - 3) + "...";
+}
+
+size_t ProgressReporter::detectTerminalWidth() const {
+    const char* columns = std::getenv("COLUMNS");
+    if (columns != nullptr) {
+        try {
+            const size_t parsed = static_cast<size_t>(std::stoul(columns));
+            if (parsed >= 20) {
+                return parsed;
+            }
+        } catch (...) {
+        }
+    }
+
+#ifdef _WIN32
+    CONSOLE_SCREEN_BUFFER_INFO csbi{};
+    if (GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &csbi) != 0) {
+        const SHORT width = static_cast<SHORT>(csbi.srWindow.Right - csbi.srWindow.Left + 1);
+        if (width > 0) {
+            return static_cast<size_t>(width);
+        }
+    }
+#else
+    winsize ws{};
+    if (ioctl(STDOUT_FILENO, TIOCGWINSZ, &ws) == 0 && ws.ws_col > 0) {
+        return static_cast<size_t>(ws.ws_col);
+    }
+#endif
+
+    return 120;
+}
+
+bool ProgressReporter::detectAnsiSupport() const {
+#ifdef _WIN32
+    HANDLE stdoutHandle = GetStdHandle(STD_OUTPUT_HANDLE);
+    if (stdoutHandle == INVALID_HANDLE_VALUE || stdoutHandle == nullptr) {
+        return false;
+    }
+
+    DWORD mode = 0;
+    if (GetConsoleMode(stdoutHandle, &mode) == 0) {
+        return false;
+    }
+
+    const DWORD wanted = mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+    if (SetConsoleMode(stdoutHandle, wanted) == 0) {
+        return false;
+    }
+    return true;
+#else
+    return true;
+#endif
 }
 
 } // namespace mosqueeze::bench

--- a/tests/unit/ProgressReporter_test.cpp
+++ b/tests/unit/ProgressReporter_test.cpp
@@ -2,10 +2,12 @@
 
 #include <cassert>
 #include <chrono>
+#include <algorithm>
 #include <iostream>
 #include <sstream>
 #include <thread>
 #include <vector>
+#include <string_view>
 
 int main() {
     using mosqueeze::bench::ProgressInfo;
@@ -69,6 +71,31 @@ int main() {
         assert(text.find("zstd L22") != std::string::npos);
         assert(text.find("iter 2/2") != std::string::npos);
         assert(text.find("ETA ") != std::string::npos);
+        const auto newlines = static_cast<int>(std::count(text.begin(), text.end(), '\n'));
+        assert(newlines <= 1);
+    }
+
+    {
+        std::ostringstream capture;
+        auto* oldBuf = std::cout.rdbuf(capture.rdbuf());
+
+        {
+            ProgressReporter reporter(2, false, false);
+            ProgressInfo info{};
+            info.totalFiles = 2;
+            info.completedFiles = 1;
+            info.progress = 0.5;
+            info.currentFile =
+                "this_is_a_very_long_filename_that_should_be_truncated_to_avoid_terminal_wrapping_progress_duplication.txt";
+            info.currentAlgorithm = "zstd";
+            info.currentLevel = 19;
+            reporter.onProgress(info);
+            std::this_thread::sleep_for(std::chrono::milliseconds(150));
+        }
+
+        std::cout.rdbuf(oldBuf);
+        const std::string text = capture.str();
+        assert(text.find("...") != std::string::npos);
     }
 
     {


### PR DESCRIPTION
## Worker Spec for #64

Fix progress bar duplicating on new lines during long benchmark runs.

### Problem
- Progress bar works for first few minutes
- Then starts printing on new lines like a log
- Fills terminal buffer

### Solution
1. Add mutex throttling (max 10 Hz updates)
2. Use ANSI escape codes `[K` to clear line
3. Enable VT processing on Windows

### Testing
Run with 1445 files + `-v` flag for 30+ minutes.

Worker spec: `docs/features/fix-64-progress-bar.md`