### PR TITLE
docs: JPEG benchmark results — compression not recommended

### DIFF
--- a/docs/benchmarks/jpeg-baseline-results.md
+++ b/docs/benchmarks/jpeg-baseline-results.md
@@ -1,0 +1,69 @@
+# JPEG Benchmark Results
+
+**Date**: 2026-04-23  
+**Corpus**: 49 JPEG files  
+**Purpose**: Confirm hypothesis that JPEG compression is not beneficial
+
+## Executive Summary
+
+**JPEG compression is NOT recommended** - standard algorithms make 60-70% of files larger.
+
+| Algorithm | Files WORSE | Files Better | Avg Ratio | Time |
+|-----------|-------------|--------------|-----------|------|
+| ZSTD/22 | **61%** | 16% | 1.008x | 379ms |
+| XZ/9 | **67%** | 14% | 1.007x | 258ms |
+| BROTLI/11 | **71%** | 27% | 1.010x | 511ms |
+| ZPAQ/5 | 0% | 39% | 1.018x | 788ms |
+
+## Key Findings
+
+### 1. Standard Algorithms Are Harmful
+
+- ZSTD/22: 61% of JPEG files get BIGGER after compression
+- XZ/9: 67% of JPEG files get BIGGER after compression  
+- BROTLI/11: 71% of JPEG files get BIGGER after compression
+
+**Why?** JPEG uses lossy DCT compression. Output has high entropy (7.95+). Compression overhead often exceeds savings.
+
+### 2. ZPAQ Is Safe But Not Worth It
+
+- Files that get bigger: **0%**
+- Average compression: **1.8%**
+- Encode time: **788ms**
+
+Not cost-effective: 788ms for 1.8% gain.
+
+### 3. Low Entropy Exception
+
+Files with entropy < 7.9 compress significantly better:
+
+| Entropy Range | Avg Ratio | Files |
+|---------------|-----------|-------|
+| < 7.9 | **1.155x** (15.5% gain) | 2 |
+| 7.9 - 7.95 | 1.030x (3% gain) | 6 |
+| > 7.95 | 1.010x (1% gain) | 41 |
+
+## Decision Rules
+
+```
+JPEG -> SKIP (compression makes most files larger)
+EXCEPTION: If entropy < 7.9, consider ZPAQ/5
+```
+
+## Comparison: JPEG vs PNG
+
+| Format | Avg Ratio | Best Ratio | Worth It? |
+|--------|-----------|------------|-----------|
+| **PNG** | 1.091x | 1.120x | **YES** (9-12% gain) |
+| **JPEG** | 1.010x | 1.189x | **NO** (1-2% gain, risk of expansion) |
+
+## Recommendations
+
+- **Do NOT compress JPEG files**
+- Archive as-is
+- Storage savings: ~0% (negligible)
+
+## Raw Data
+
+- Location: G:\mosqueeze-bench\results\jpeg-baseline\
+- Measurements: 196 (49 files x 4 algorithms)

--- a/docs/wiki/benchmarks/results/index.md
+++ b/docs/wiki/benchmarks/results/index.md
@@ -29,6 +29,20 @@
 - **Oxipng preprocessing**: +2.5% compression improvement
 - **Best config**: Oxipng + ZSTD/22 = 1.120x ratio (370ms)
 
+
+### 2026-04-23 — JPEG Benchmark
+
+**Corpus**: 49 JPEG files
+
+**Results**: [JPEG Baseline Results](../../../../benchmarks/jpeg-baseline-results.md)
+
+**Highlights**:
+- **JPEG is NOT compressible** — 60-70% files get larger
+- ZSTD/22: 61% files worse, avg ratio 1.008x
+- ZPAQ/5: safe but only +2% gain, 788ms
+- **Recommendation**: SKIP JPEG compression
+
+
 ### 2026-04-22 — Initial Benchmark
 
 **Commit**: `aa48401`

--- a/docs/wiki/decisions/file-type-to-algorithm.md
+++ b/docs/wiki/decisions/file-type-to-algorithm.md
@@ -36,6 +36,21 @@
 - ZSTD/19 = ZSTD/22 in ratio ma 4x più veloce
 - **Raccomandazione**: oxipng + ZSTD/22 per cold storage
 
+
+### JPEG Findings (benchmark 2026-04-23, 49 files):
+
+- JPEG è **già lossy-compresso** → 60-70% file diventano più grandi
+- **SKIP raccomandato** per tutti i casi eccetto entropia molto bassa
+- Eccezione: Entropia < 7.9 → considerare ZPAQ/5 (+15% potenziale)
+
+| Algorithm | Files Peggiorati | Avg Ratio |
+|-----------|------------------|-----------|
+| ZSTD/22 | 61% | 1.008x |
+| XZ/9 | 67% | 1.007x |
+| BROTLI/11 | 71% | 1.010x |
+| ZPAQ/5 | 0% | 1.018x (sicuro ma lento) |
+
+
 ### Binary Files
 
 | FileType | Algoritmo | Livello | Motivazione |


### PR DESCRIPTION
## Summary

Aggiunti risultati benchmark JPEG (49 files).

### Key Findings

| Algorithm | Files WORSE | Avg Ratio |
|-----------|-------------|-----------|
| ZSTD/22 | **61%** | 1.008x |
| XZ/9 | **67%** | 1.007x |
| BROTLI/11 | **71%** | 1.010x |
| ZPAQ/5 | 0% | 1.018x |

### Recommendation

**JPEG → SKIP** — standard algorithms make 60-70% of files larger.

Exception: If entropy < 7.9, ZPAQ/5 may help.

---

- File: `docs/benchmarks/jpeg-baseline-results.md`
