### PR TITLE
docs: worker spec for #67 CLI compress/decompress commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ cmake --build build
 
 # Recommendation with explicit goal and JSON output
 ./build/src/mosqueeze-cli/mosqueeze suggest ./data/sample.png --goal fastest --json
+
+# Compress/decompress
+./build/src/mosqueeze-cli/mosqueeze compress ./data/input.bin -o ./data/input.msz -a zstd
+./build/src/mosqueeze-cli/mosqueeze decompress ./data/input.msz -o ./data/input.restored.bin
 ```
 
 Expected output:

--- a/docs/features/feat-67-cli-compress-decompress.md
+++ b/docs/features/feat-67-cli-compress-decompress.md
@@ -1,0 +1,383 @@
+# Worker Spec: CLI Compress/Decompress Commands (#67)
+
+## Issue
+https://github.com/fathorMB/MoSqueeze/issues/67
+
+## Overview
+Add `compress` and `decompress` commands to `mosqueeze-cli` to enable programmatic compression from TheVault and other tools.
+
+## Requirements
+
+### `compress` command
+```bash
+mosqueeze compress <input> -o <output> -a <algorithm> [-l <level>] [--preprocess <type>] [--json]
+```
+
+| Flag | Description | Values |
+|------|-------------|--------|
+| `-a,--algorithm` | Compression algorithm | `zstd`, `brotli`, `lzma`, `zpaq` |
+| `-l,--level` | Compression level | zstd: 1-22, brotli: 0-11, lzma: 0-9, zpaq: 1-5 |
+| `-o,--output` | Output file path | Required |
+| `--preprocess` | Preprocessor type | `none`, `json-canonical`, `xml-canonical`, `image-meta-strip`, `png-optimizer`, `bayer-raw` |
+| `--json` | JSON output to stdout | Machine-readable format |
+| `--level` defaults | zstd: 3, brotli: 6, lzma: 6, zpaq: 3 |
+
+### `decompress` command
+```bash
+mosqueeze decompress <input> [-o <output>] [--json]
+```
+
+| Flag | Description |
+|------|-------------|
+| `-o,--output` | Output file (default: input without `.msz` extension) |
+| `--json` | JSON output to stdout |
+
+### JSON Output Format
+```json
+{
+  "success": true,
+  "input": "/path/to/input.dat",
+  "output": "/path/to/output.msz",
+  "inputSize": 1000000,
+  "outputSize": 300000,
+  "ratio": 0.30,
+  "algorithm": "zstd",
+  "level": 3,
+  "preprocessor": "none"
+}
+```
+
+Error format:
+```json
+{
+  "success": false,
+  "error": "Failed to compress: file not found",
+  "input": "/path/to/input.dat"
+}
+```
+
+### Stdin/Stdout Mode
+When input is `-` or `-o -`:
+- Read from stdin, write to stdout
+- Useful for piping: `cat file.dat | mosqueeze compress - -a zstd | ...`
+
+## Implementation
+
+### New Files
+```
+src/mosqueeze-cli/src/commands/
+├── CompressCommand.cpp
+├── CompressCommand.hpp
+├── DecompressCommand.cpp
+└── DecompressCommand.hpp
+```
+
+### File Changes
+
+#### `src/mosqueeze-cli/src/main.cpp`
+Add subcommand registration:
+```cpp
+#include "commands/CompressCommand.hpp"
+#include "commands/DecompressCommand.hpp"
+
+// In main():
+addCompressCommand(app);
+addDecompressCommand(app);
+```
+
+#### `src/mosqueeze-cli/CMakeLists.txt`
+Add new source files:
+```cmake
+target_sources(mosqueeze PRIVATE
+    src/main.cpp
+    src/commands/CompressCommand.cpp
+    src/commands/DecompressCommand.cpp
+)
+```
+
+### CompressCommand Implementation
+
+```cpp
+// src/mosqueeze-cli/src/commands/CompressCommand.hpp
+#pragma once
+#include <CLI/CLI.hpp>
+#include <mosqueeze/CompressionPipeline.hpp>
+#include <mosqueeze/engines/ZstdEngine.hpp>
+#include <mosqueeze/engines/BrotliEngine.hpp>
+#include <mosqueeze/engines/LzmaEngine.hpp>
+#include <mosqueeze/engines/ZpaqEngine.hpp>
+
+namespace mosqueeze::cli {
+
+struct CompressOptions {
+    std::string inputFile;
+    std::string outputFile;
+    std::string algorithm;
+    int level{-1};  // -1 = use default
+    std::string preprocess{"none"};
+    bool jsonOutput{false};
+};
+
+void addCompressCommand(CLI::App& app);
+
+ICompressionEngine* createEngine(const std::string& algorithm);
+
+int runCompress(const CompressOptions& opts);
+
+} // namespace mosqueeze::cli
+```
+
+```cpp
+// src/mosqueeze-cli/src/commands/CompressCommand.cpp
+#include "CompressCommand.hpp"
+#include <mosqueeze/preprocessors/JsonCanonicalizer.hpp>
+#include <mosqueeze/preprocessors/XmlCanonicalizer.hpp>
+#include <mosqueeze/preprocessors/ImageMetaStripper.hpp>
+#include <mosqueeze/preprocessors/PngOptimizer.hpp>
+#include <mosquee/preprocessors/BayerPreprocessor.hpp>
+#include <fmt/format.h>
+#include <fstream>
+#include <sstream>
+#include <memory>
+
+namespace mosqueeze::cli {
+
+void addCompressCommand(CLI::App& app) {
+    auto* compress = app.add_subcommand("compress", "Compress a file");
+    
+    auto opts = std::make_shared<CompressOptions>();
+    
+    compress->add_option("input", opts->inputFile, "Input file (use - for stdin)")
+        ->required();
+    compress->add_option("-o,--output", opts->outputFile, "Output file (use - for stdout)")
+        ->required();
+    compress->add_option("-a,--algorithm", opts->algorithm, "Algorithm: zstd, brotli, lzma, zpaq")
+        ->default_val("zstd")
+        ->check(CLI::IsMember({"zstd", "brotli", "lzma", "zpaq"}));
+    compress->add_option("-l,--level", opts->level, "Compression level (default: algo-specific)");
+    compress->add_option("--preprocess", opts->preprocess, "Preprocessor type")
+        ->default_val("none")
+        ->check(CLI::IsMember({"none", "json-canonical", "xml-canonical", "image-meta-strip", "png-optimizer", "bayer-raw"}));
+    compress->add_flag("--json", opts->jsonOutput, "Output result as JSON");
+    
+    compress->callback([opts]() {
+        const int exitCode = runCompress(*opts);
+        if (exitCode != 0) {
+            throw CLI::RuntimeError(exitCode);
+        }
+    });
+}
+
+ICompressionEngine* createEngine(const std::string& algorithm) {
+    static ZstdEngine zstd;
+    static BrotliEngine brotli;
+    static LzmaEngine lzma;
+    static ZpaqEngine zpaq;
+    
+    if (algorithm == "zstd") return &zstd;
+    if (algorithm == "brotli") return &brotli;
+    if (algorithm == "lzma") return &lzma;
+    if (algorithm == "zpaq") return &zpaq;
+    
+    return &zstd; // default
+}
+
+int getDefaultLevel(const std::string& algorithm) {
+    // Conservative defaults for cold storage
+    if (algorithm == "zstd") return 3;
+    if (algorithm == "brotli") return 6;
+    if (algorithm == "lzma") return 6;
+    if (algorithm == "zpaq") return 3;
+    return 3;
+}
+
+int runCompress(const CompressOptions& opts) {
+    try {
+        // Validate input
+        if (opts.inputFile != "-" && !std::filesystem::exists(opts.inputFile)) {
+            if (opts.jsonOutput) {
+                fmt::print("{{\"success\":false,\"error\":\"Input file not found\",\"input\":\"{}\"}}\n", opts.inputFile);
+            } else {
+                fmt::print(stderr, "Error: Input file not found: {}\n", opts.inputFile);
+            }
+            return 1;
+        }
+        
+        // Determine level
+        const int level = (opts.level >= 0) ? opts.level : getDefaultLevel(opts.algorithm);
+        
+        // Create engine and pipeline
+        auto* engine = createEngine(opts.algorithm);
+        CompressionPipeline pipeline(engine);
+        
+        // Set preprocessor if not "none"
+        std::unique_ptr<IPreprocessor> preprocessor;
+        if (opts.preprocess == "json-canonical") {
+            preprocessor = std::make_unique<JsonCanonicalizer>();
+        } else if (opts.preprocess == "xml-canonical") {
+            preprocessor = std::make_unique<XmlCanonicalizer>();
+        } else if (opts.preprocess == "image-meta-strip") {
+            preprocessor = std::make_unique<ImageMetaStripper>();
+        } else if (opts.preprocess == "png-optimizer") {
+            preprocessor = std::make_unique<PngOptimizer>();
+        } else if (opts.preprocess == "bayer-raw") {
+            preprocessor = std::make_unique<BayerPreprocessor>();
+        }
+        
+        if (preprocessor) {
+            pipeline.setPreprocessor(preprocessor.get());
+        }
+        
+        // Open streams
+        std::ifstream inFile;
+        std::ofstream outFile;
+        std::istream* input = nullptr;
+        std::ostream* output = nullptr;
+        
+        if (opts.inputFile == "-") {
+            input = &std::cin;
+        } else {
+            inFile.open(opts.inputFile, std::ios::binary);
+            input = &inFile;
+        }
+        
+        if (opts.outputFile == "-") {
+            output = &std::cout;
+        } else {
+            outFile.open(opts.outputFile, std::ios::binary);
+            output = &outFile;
+        }
+        
+        // Compress
+        CompressionOptions compOpts;
+        compOpts.level = level;
+        
+        const auto sizeBefore = opts.inputFile != "-" 
+            ? std::filesystem::file_size(opts.inputFile) 
+            : 0; // stdin size unknown
+        
+        auto result = pipeline.compress(*input, *output, compOpts);
+        
+        // Get output size
+        const auto sizeAfter = opts.outputFile != "-"
+            ? std::filesystem::file_size(opts.outputFile)
+            : result.compression.outputSize; // from result
+        
+        // Output result
+        if (opts.jsonOutput) {
+            fmt::print(
+                "{{\"success\":true,\"input\":\"{}\",\"output\":\"{}\","
+                "\"inputSize\":{},\"outputSize\":{},\"ratio\":{:.3f},"
+                "\"algorithm\":\"{}\",\"level\":{},\"preprocessor\":\"{}\"}}\n",
+                opts.inputFile, opts.outputFile,
+                sizeBefore, sizeAfter,
+                static_cast<double>(sizeAfter) / static_cast<double>(sizeBefore ?: 1),
+                opts.algorithm, level, opts.preprocess
+            );
+        } else {
+            fmt::print("Compressed {} → {}\n", opts.inputFile, opts.outputFile);
+            fmt::print("  Algorithm: {} level {}\n", opts.algorithm, level);
+            fmt::print("  Size: {} → {} bytes ({:.1f}%)\n", 
+                sizeBefore, sizeAfter, 
+                100.0 * sizeAfter / (sizeBefore ?: 1));
+        }
+        
+        return 0;
+        
+    } catch (const std::exception& e) {
+        if (opts.jsonOutput) {
+            fmt::print("{{\"success\":false,\"error\":\"{}\"}}\n", e.what());
+        } else {
+            fmt::print(stderr, "Error: {}\n", e.what());
+        }
+        return 2;
+    }
+}
+
+} // namespace mosqueeze::cli
+```
+
+### DecompressCommand Implementation
+
+```cpp
+// src/mosqueeze-cli/src/commands/DecompressCommand.cpp
+// Similar structure to CompressCommand but:
+// - Detect algorithm from trailing header or file extension
+// - Call pipeline.decompress()
+// - Handle preprocessor reconstruction automatically
+```
+
+## Test Requirements
+
+### Unit Tests (`tests/unit/CompressCommand_test.cpp`)
+```cpp
+// Test algorithm selection
+TEST(CompressCommand, SelectsCorrectEngine) { ... }
+
+// Test level defaults
+TEST(CompressCommand, DefaultLevelsPerAlgorithm) { ... }
+
+// Test JSON output format
+TEST(CompressCommand, JsonOutputFormat) { ... }
+
+// Test error handling
+TEST(CompressCommand, FileNotFoundError) { ... }
+```
+
+### Integration Tests
+```bash
+# Basic compression
+./mosqueeze compress test.dat -o test.msz -a zstd
+
+# Roundtrip
+./mosqueeze compress test.dat -o test.msz -a zstd
+./mosqueeze decompress test.msz -o test.restored
+diff test.dat test.restored  # should be identical
+
+# JSON output parsing
+./mosqueeze compress test.dat -o test.msz -a zstd --json | jq .success  # should be true
+```
+
+## Edge Cases
+
+### Input Does Not Exist
+- Exit code: 1
+- JSON: `{"success": false, "error": "Input file not found"}`
+
+### Invalid Algorithm
+- CLI11 will reject before callback
+
+### Invalid Level for Algorithm
+- Engine will throw; catch and report
+
+### Stdin Compression (input size unknown)
+- JSON: `inputSize: 0`, `ratio: 0.0` (can't calculate)
+
+## Dependencies
+
+### Must Use
+- `CompressionPipeline` from libmosqueeze (already exists)
+- All engine implementations (already exist)
+- All preprocessor implementations (already exist)
+
+### No New Dependencies
+- Uses existing CLI11, fmt, spdlog
+
+## Exit Codes
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 1 | Input file not found |
+| 2 | Compression/decompression error |
+| 3 | Invalid arguments (handled by CLI11) |
+
+## Performance Considerations
+- Files are read entirely into memory (via istream)
+- For large files (>1GB), consider streaming implementation later
+- Preprocessors may need extra memory for in-memory transformation
+
+## Future Enhancements (Out of Scope)
+- Progress reporting during compression
+- Multi-file batch compression
+- Resume partial compression
+- Custom output extension (currently `.msz`)

--- a/docs/wiki/guides/getting-started.md
+++ b/docs/wiki/guides/getting-started.md
@@ -160,37 +160,39 @@ From `vcpkg.json`:
 ### Basic Usage
 
 ```bash
-# Compress a file
-./mosqueeze-cli compress input.txt output.zst
+# Analyze recommendation
+./build/src/mosqueeze-cli/mosqueeze analyze ./data/sample.json
 
-# Compress with specific algorithm
-./mosqueeze-cli compress input.txt output.xz --algorithm lzma
+# Intelligent recommendation
+./build/src/mosqueeze-cli/mosqueeze suggest ./data/sample.json --goal min-size --json
 
-# Compress with level
-./mosqueeze-cli compress input.txt output.br --algorithm brotli --level 11
+# Compress with explicit algorithm/level/preprocessor
+./build/src/mosqueeze-cli/mosqueeze compress ./data/input.json -o ./data/input.msz -a zstd -l 3 --preprocess json-canonical
 
-# Decompress
-./mosqueeze-cli decompress output.zst restored.txt
-
-# Detect file type
-./mosqueeze-cli detect mystery.bin
+# Decompress (default output removes .msz suffix)
+./build/src/mosqueeze-cli/mosqueeze decompress ./data/input.msz
 ```
 
 ### Options
 
 ```
-Usage: mosqueeze-cli [OPTIONS] COMMAND [ARGS...]
+Usage: mosqueeze [OPTIONS] COMMAND [ARGS...]
 
 Commands:
-  compress     Compress a file
-  decompress   Decompress a file
-  detect       Detect file type
+  analyze       Analyze file and recommend algorithm
+  suggest       Intelligent compression suggestion
+  compress      Compress a file
+  decompress    Decompress a file
 
 Compress options:
-  --algorithm ALG    zstd (default), lzma, brotli
-  --level N          Compression level (algorithm-specific)
-  --extreme          Enable ultra mode (cold storage)
-  --verify           Verify after compression
+  -a, --algorithm    zstd|brotli|lzma|zpaq
+  -l, --level        Compression level (algorithm-specific)
+      --preprocess   none|json-canonical|xml-canonical|image-meta-strip|png-optimizer|bayer-raw
+      --json         Machine-readable result output
+
+Decompress options:
+  -o, --output       Output file (default: input without `.msz`)
+      --json         Machine-readable result output
 
 Global options:
   --version          Show version

--- a/docs/wiki/log.md
+++ b/docs/wiki/log.md
@@ -117,3 +117,7 @@ Initial wiki population for Issue #16 â€” focus on algorithmic decision-mak
 ### Feature Docs: Extended Benchmark Plan
 - Updated `guides/benchmark-tool.md` with extended matrix mode (`--extended`, `--preprocessors`), resume behavior, and round-trip verification
 - Documented new export fields for file features and verification outcomes in benchmark JSON/CSV output
+
+### Feature Docs: CLI Compress/Decompress (Issue #67)
+- Updated `guides/getting-started.md` CLI section with current `mosqueeze` command usage
+- Added examples for `mosqueeze compress` and `mosqueeze decompress` including JSON mode and preprocess selection

--- a/src/mosqueeze-cli/CMakeLists.txt
+++ b/src/mosqueeze-cli/CMakeLists.txt
@@ -1,9 +1,12 @@
-﻿find_package(CLI11 CONFIG REQUIRED)
+find_package(CLI11 CONFIG REQUIRED)
 find_package(fmt CONFIG REQUIRED)
 find_package(spdlog CONFIG REQUIRED)
+find_package(nlohmann_json CONFIG REQUIRED)
 
 add_executable(mosqueeze
   src/main.cpp
+  src/commands/CompressCommand.cpp
+  src/commands/DecompressCommand.cpp
 )
 
 target_link_libraries(mosqueeze
@@ -12,6 +15,7 @@ target_link_libraries(mosqueeze
     CLI11::CLI11
     fmt::fmt
     spdlog::spdlog
+    nlohmann_json::nlohmann_json
 )
 
 if(WIN32)

--- a/src/mosqueeze-cli/src/commands/CompressCommand.cpp
+++ b/src/mosqueeze-cli/src/commands/CompressCommand.cpp
@@ -1,0 +1,242 @@
+#include "CompressCommand.hpp"
+
+#include <mosqueeze/CompressionPipeline.hpp>
+#include <mosqueeze/Preprocessor.hpp>
+#include <mosqueeze/engines/BrotliEngine.hpp>
+#include <mosqueeze/engines/LzmaEngine.hpp>
+#include <mosqueeze/engines/ZpaqEngine.hpp>
+#include <mosqueeze/engines/ZstdEngine.hpp>
+#include <mosqueeze/preprocessors/BayerPreprocessor.hpp>
+#include <mosqueeze/preprocessors/ImageMetaStripper.hpp>
+#include <mosqueeze/preprocessors/JsonCanonicalizer.hpp>
+#include <mosqueeze/preprocessors/PngOptimizer.hpp>
+#include <mosqueeze/preprocessors/XmlCanonicalizer.hpp>
+
+#include <fmt/format.h>
+#include <nlohmann/json.hpp>
+
+#include <algorithm>
+#include <filesystem>
+#include <fstream>
+#include <ios>
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
+#include <vector>
+
+#ifdef _WIN32
+#include <fcntl.h>
+#include <io.h>
+#endif
+
+namespace mosqueeze::cli {
+namespace {
+
+void setBinaryModeIfNeeded(bool useInputStdIn, bool useOutputStdOut) {
+#ifdef _WIN32
+    if (useInputStdIn) {
+        _setmode(_fileno(stdin), _O_BINARY);
+    }
+    if (useOutputStdOut) {
+        _setmode(_fileno(stdout), _O_BINARY);
+    }
+#else
+    (void)useInputStdIn;
+    (void)useOutputStdOut;
+#endif
+}
+
+void emitErrorJson(const std::string& input, const std::string& message) {
+    nlohmann::json payload{
+        {"success", false},
+        {"error", message},
+        {"input", input}
+    };
+    fmt::print("{}\n", payload.dump());
+}
+
+} // namespace
+
+void addCompressCommand(CLI::App& app) {
+    auto* compress = app.add_subcommand("compress", "Compress a file");
+
+    auto opts = std::make_shared<CompressOptions>();
+
+    compress->add_option("input", opts->inputFile, "Input file (use - for stdin)")
+        ->required();
+    compress->add_option("-o,--output", opts->outputFile, "Output file (use - for stdout)")
+        ->required();
+    compress->add_option("-a,--algorithm", opts->algorithm, "Algorithm: zstd, brotli, lzma, zpaq")
+        ->default_val("zstd")
+        ->check(CLI::IsMember({"zstd", "brotli", "lzma", "zpaq"}));
+    compress->add_option("-l,--level", opts->level, "Compression level (default: algo-specific)");
+    compress->add_option("--preprocess", opts->preprocess, "Preprocessor type")
+        ->default_val("none")
+        ->check(CLI::IsMember({"none", "json-canonical", "xml-canonical", "image-meta-strip", "png-optimizer", "bayer-raw"}));
+    compress->add_flag("--json", opts->jsonOutput, "Output result as JSON");
+
+    compress->callback([opts]() {
+        const int exitCode = runCompress(*opts);
+        if (exitCode != 0) {
+            throw CLI::RuntimeError(exitCode);
+        }
+    });
+}
+
+std::unique_ptr<ICompressionEngine> createEngine(const std::string& algorithm) {
+    if (algorithm == "zstd") {
+        return std::make_unique<ZstdEngine>();
+    }
+    if (algorithm == "brotli") {
+        return std::make_unique<BrotliEngine>();
+    }
+    if (algorithm == "lzma") {
+        return std::make_unique<LzmaEngine>();
+    }
+    if (algorithm == "zpaq") {
+        return std::make_unique<ZpaqEngine>();
+    }
+    throw std::runtime_error("Unsupported algorithm: " + algorithm);
+}
+
+std::unique_ptr<IPreprocessor> createPreprocessor(const std::string& preprocess) {
+    if (preprocess == "none") {
+        return nullptr;
+    }
+    if (preprocess == "json-canonical") {
+        return std::make_unique<JsonCanonicalizer>();
+    }
+    if (preprocess == "xml-canonical") {
+        return std::make_unique<XmlCanonicalizer>();
+    }
+    if (preprocess == "image-meta-strip") {
+        return std::make_unique<ImageMetaStripper>();
+    }
+    if (preprocess == "png-optimizer") {
+        return std::make_unique<PngOptimizer>();
+    }
+    if (preprocess == "bayer-raw") {
+        return std::make_unique<BayerPreprocessor>();
+    }
+    throw std::runtime_error("Unsupported preprocessor: " + preprocess);
+}
+
+int defaultLevelFor(const std::string& algorithm) {
+    if (algorithm == "zstd") {
+        return 3;
+    }
+    if (algorithm == "brotli") {
+        return 6;
+    }
+    if (algorithm == "lzma") {
+        return 6;
+    }
+    if (algorithm == "zpaq") {
+        return 3;
+    }
+    return 3;
+}
+
+int runCompress(const CompressOptions& opts) {
+    try {
+        const bool useInputStdIn = opts.inputFile == "-";
+        const bool useOutputStdOut = opts.outputFile == "-";
+        setBinaryModeIfNeeded(useInputStdIn, useOutputStdOut);
+
+        if (!useInputStdIn && !std::filesystem::exists(opts.inputFile)) {
+            if (opts.jsonOutput) {
+                emitErrorJson(opts.inputFile, "Input file not found");
+            } else {
+                fmt::print(stderr, "Error: Input file not found: {}\n", opts.inputFile);
+            }
+            return 1;
+        }
+
+        auto engine = createEngine(opts.algorithm);
+        const auto supportedLevels = engine->supportedLevels();
+        const int level = opts.level >= 0 ? opts.level : defaultLevelFor(opts.algorithm);
+        if (std::find(supportedLevels.begin(), supportedLevels.end(), level) == supportedLevels.end()) {
+            throw std::runtime_error(
+                "Invalid level " + std::to_string(level) + " for algorithm " + opts.algorithm);
+        }
+
+        auto preprocessor = createPreprocessor(opts.preprocess);
+        CompressionPipeline pipeline(engine.get());
+        if (preprocessor) {
+            pipeline.setPreprocessor(preprocessor.get());
+        }
+
+        std::ifstream inFile;
+        std::ofstream outFile;
+        std::istream* input = &std::cin;
+        std::ostream* output = &std::cout;
+
+        if (!useInputStdIn) {
+            inFile.open(opts.inputFile, std::ios::binary);
+            if (!inFile) {
+                throw std::runtime_error("Failed to open input file: " + opts.inputFile);
+            }
+            input = &inFile;
+        }
+
+        if (!useOutputStdOut) {
+            std::filesystem::path outPath(opts.outputFile);
+            if (outPath.has_parent_path()) {
+                std::filesystem::create_directories(outPath.parent_path());
+            }
+            outFile.open(opts.outputFile, std::ios::binary);
+            if (!outFile) {
+                throw std::runtime_error("Failed to open output file: " + opts.outputFile);
+            }
+            output = &outFile;
+        }
+
+        CompressionOptions compOpts{};
+        compOpts.level = level;
+        const PipelineResult pipelineResult = pipeline.compress(*input, *output, compOpts);
+        output->flush();
+
+        const size_t inputSize = pipelineResult.wasPreprocessed
+            ? pipelineResult.preprocessing.originalBytes
+            : pipelineResult.compression.originalBytes;
+        const size_t outputSize = pipelineResult.compression.compressedBytes +
+            static_cast<size_t>(9 + pipelineResult.preprocessing.metadata.size());
+        const double ratio = inputSize > 0
+            ? static_cast<double>(outputSize) / static_cast<double>(inputSize)
+            : 0.0;
+
+        if (opts.jsonOutput) {
+            nlohmann::json payload{
+                {"success", true},
+                {"input", opts.inputFile},
+                {"output", opts.outputFile},
+                {"inputSize", inputSize},
+                {"outputSize", outputSize},
+                {"ratio", ratio},
+                {"algorithm", opts.algorithm},
+                {"level", level},
+                {"preprocessor", opts.preprocess}
+            };
+            fmt::print("{}\n", payload.dump());
+        } else {
+            fmt::print("Compressed {} -> {}\n", opts.inputFile, opts.outputFile);
+            fmt::print("  Algorithm: {} level {}\n", opts.algorithm, level);
+            fmt::print("  Preprocess: {}\n", opts.preprocess);
+            fmt::print("  Size: {} -> {} bytes ({:.1f}%)\n",
+                       inputSize,
+                       outputSize,
+                       inputSize > 0 ? (100.0 * static_cast<double>(outputSize) / static_cast<double>(inputSize)) : 0.0);
+        }
+
+        return 0;
+    } catch (const std::exception& e) {
+        if (opts.jsonOutput) {
+            emitErrorJson(opts.inputFile, e.what());
+        } else {
+            fmt::print(stderr, "Error: {}\n", e.what());
+        }
+        return 2;
+    }
+}
+
+} // namespace mosqueeze::cli

--- a/src/mosqueeze-cli/src/commands/CompressCommand.hpp
+++ b/src/mosqueeze-cli/src/commands/CompressCommand.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <CLI/CLI.hpp>
+
+#include <memory>
+#include <string>
+
+namespace mosqueeze {
+class ICompressionEngine;
+class IPreprocessor;
+}
+
+namespace mosqueeze::cli {
+
+struct CompressOptions {
+    std::string inputFile;
+    std::string outputFile;
+    std::string algorithm = "zstd";
+    int level = -1;
+    std::string preprocess = "none";
+    bool jsonOutput = false;
+};
+
+void addCompressCommand(CLI::App& app);
+
+std::unique_ptr<ICompressionEngine> createEngine(const std::string& algorithm);
+std::unique_ptr<IPreprocessor> createPreprocessor(const std::string& preprocess);
+int defaultLevelFor(const std::string& algorithm);
+int runCompress(const CompressOptions& opts);
+
+} // namespace mosqueeze::cli

--- a/src/mosqueeze-cli/src/commands/DecompressCommand.cpp
+++ b/src/mosqueeze-cli/src/commands/DecompressCommand.cpp
@@ -1,0 +1,244 @@
+#include "DecompressCommand.hpp"
+
+#include "CompressCommand.hpp"
+
+#include <mosqueeze/CompressionPipeline.hpp>
+#include <mosqueeze/ICompressionEngine.hpp>
+
+#include <fmt/format.h>
+#include <nlohmann/json.hpp>
+
+#include <algorithm>
+#include <filesystem>
+#include <fstream>
+#include <ios>
+#include <iostream>
+#include <memory>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#ifdef _WIN32
+#include <fcntl.h>
+#include <io.h>
+#endif
+
+namespace mosqueeze::cli {
+namespace {
+
+void setBinaryModeIfNeeded(bool useInputStdIn, bool useOutputStdOut) {
+#ifdef _WIN32
+    if (useInputStdIn) {
+        _setmode(_fileno(stdin), _O_BINARY);
+    }
+    if (useOutputStdOut) {
+        _setmode(_fileno(stdout), _O_BINARY);
+    }
+#else
+    (void)useInputStdIn;
+    (void)useOutputStdOut;
+#endif
+}
+
+void emitErrorJson(const std::string& input, const std::string& message) {
+    nlohmann::json payload{
+        {"success", false},
+        {"error", message},
+        {"input", input}
+    };
+    fmt::print("{}\n", payload.dump());
+}
+
+std::string deriveOutputPath(const std::string& input) {
+    if (input == "-") {
+        return "-";
+    }
+
+    std::filesystem::path path(input);
+    if (path.extension() == ".msz") {
+        path.replace_extension();
+        return path.string();
+    }
+    return path.string() + ".out";
+}
+
+bool hasPrefix(const std::string& value, const std::vector<uint8_t>& magic) {
+    return value.size() >= magic.size() &&
+        std::equal(magic.begin(), magic.end(), reinterpret_cast<const uint8_t*>(value.data()));
+}
+
+std::vector<std::string> detectCandidateAlgorithms(
+    const std::string& payload,
+    const std::string& inputFile) {
+    std::vector<std::string> candidates;
+
+    // Magic-based first.
+    if (hasPrefix(payload, {0x28, 0xB5, 0x2F, 0xFD})) {
+        candidates.push_back("zstd");
+    }
+    if (hasPrefix(payload, {0xFD, 0x37, 0x7A, 0x58, 0x5A, 0x00})) {
+        candidates.push_back("lzma");
+    }
+    // zpaq streams often start with "zPQ" marker.
+    if (payload.size() >= 3 && payload[0] == 'z' && payload[1] == 'P' && payload[2] == 'Q') {
+        candidates.push_back("zpaq");
+    }
+
+    // Extension hints second.
+    if (inputFile != "-") {
+        const std::string ext = std::filesystem::path(inputFile).extension().string();
+        if (ext == ".zst" || ext == ".zstd") {
+            candidates.push_back("zstd");
+        } else if (ext == ".xz" || ext == ".lzma") {
+            candidates.push_back("lzma");
+        } else if (ext == ".br") {
+            candidates.push_back("brotli");
+        } else if (ext == ".zpaq") {
+            candidates.push_back("zpaq");
+        }
+    }
+
+    // Fallback order with brotli included.
+    for (const std::string& algo : {"zstd", "lzma", "brotli", "zpaq"}) {
+        candidates.push_back(algo);
+    }
+
+    std::vector<std::string> unique;
+    unique.reserve(candidates.size());
+    for (const auto& candidate : candidates) {
+        if (std::find(unique.begin(), unique.end(), candidate) == unique.end()) {
+            unique.push_back(candidate);
+        }
+    }
+    return unique;
+}
+
+std::pair<std::string, std::string> tryDecompressWithDetection(
+    const std::string& compressedPayload,
+    const std::string& inputFile) {
+    std::string lastError;
+    for (const auto& algorithm : detectCandidateAlgorithms(compressedPayload, inputFile)) {
+        try {
+            auto engine = createEngine(algorithm);
+            CompressionPipeline pipeline(engine.get());
+            std::istringstream in(compressedPayload);
+            std::ostringstream out;
+            pipeline.decompress(in, out);
+            return {algorithm, out.str()};
+        } catch (const std::exception& e) {
+            lastError = e.what();
+        }
+    }
+    throw std::runtime_error(
+        "Failed to detect decompression algorithm for input. Last error: " + lastError);
+}
+
+} // namespace
+
+void addDecompressCommand(CLI::App& app) {
+    auto* decompress = app.add_subcommand("decompress", "Decompress a file");
+    auto opts = std::make_shared<DecompressOptions>();
+
+    decompress->add_option("input", opts->inputFile, "Input file (use - for stdin)")
+        ->required();
+    decompress->add_option("-o,--output", opts->outputFile, "Output file (default: input without .msz)");
+    decompress->add_flag("--json", opts->jsonOutput, "Output result as JSON");
+
+    decompress->callback([opts]() {
+        const int exitCode = runDecompress(*opts);
+        if (exitCode != 0) {
+            throw CLI::RuntimeError(exitCode);
+        }
+    });
+}
+
+int runDecompress(const DecompressOptions& opts) {
+    try {
+        const bool useInputStdIn = opts.inputFile == "-";
+        const std::string resolvedOutput = opts.outputFile.empty() ? deriveOutputPath(opts.inputFile) : opts.outputFile;
+        const bool useOutputStdOut = resolvedOutput == "-";
+        setBinaryModeIfNeeded(useInputStdIn, useOutputStdOut);
+
+        if (!useInputStdIn && !std::filesystem::exists(opts.inputFile)) {
+            if (opts.jsonOutput) {
+                emitErrorJson(opts.inputFile, "Input file not found");
+            } else {
+                fmt::print(stderr, "Error: Input file not found: {}\n", opts.inputFile);
+            }
+            return 1;
+        }
+
+        std::ifstream inFile;
+        std::istream* input = &std::cin;
+        if (!useInputStdIn) {
+            inFile.open(opts.inputFile, std::ios::binary);
+            if (!inFile) {
+                throw std::runtime_error("Failed to open input file: " + opts.inputFile);
+            }
+            input = &inFile;
+        }
+
+        const std::string compressedPayload{
+            std::istreambuf_iterator<char>(*input),
+            std::istreambuf_iterator<char>()};
+        const size_t inputSize = compressedPayload.size();
+
+        const auto [algorithm, decompressedPayload] =
+            tryDecompressWithDetection(compressedPayload, opts.inputFile);
+        const size_t outputSize = decompressedPayload.size();
+
+        std::ofstream outFile;
+        std::ostream* output = &std::cout;
+        if (!useOutputStdOut) {
+            std::filesystem::path outPath(resolvedOutput);
+            if (outPath.has_parent_path()) {
+                std::filesystem::create_directories(outPath.parent_path());
+            }
+            outFile.open(resolvedOutput, std::ios::binary);
+            if (!outFile) {
+                throw std::runtime_error("Failed to open output file: " + resolvedOutput);
+            }
+            output = &outFile;
+        }
+
+        output->write(decompressedPayload.data(), static_cast<std::streamsize>(decompressedPayload.size()));
+        output->flush();
+
+        const double ratio = inputSize > 0
+            ? static_cast<double>(outputSize) / static_cast<double>(inputSize)
+            : 0.0;
+
+        if (opts.jsonOutput) {
+            nlohmann::json payload{
+                {"success", true},
+                {"input", opts.inputFile},
+                {"output", resolvedOutput},
+                {"inputSize", inputSize},
+                {"outputSize", outputSize},
+                {"ratio", ratio},
+                {"algorithm", algorithm}
+            };
+            fmt::print("{}\n", payload.dump());
+        } else {
+            fmt::print("Decompressed {} -> {}\n", opts.inputFile, resolvedOutput);
+            fmt::print("  Algorithm: {}\n", algorithm);
+            fmt::print("  Size: {} -> {} bytes ({:.1f}%)\n",
+                       inputSize,
+                       outputSize,
+                       inputSize > 0 ? (100.0 * static_cast<double>(outputSize) / static_cast<double>(inputSize)) : 0.0);
+        }
+
+        return 0;
+    } catch (const std::exception& e) {
+        if (opts.jsonOutput) {
+            emitErrorJson(opts.inputFile, e.what());
+        } else {
+            fmt::print(stderr, "Error: {}\n", e.what());
+        }
+        return 2;
+    }
+}
+
+} // namespace mosqueeze::cli

--- a/src/mosqueeze-cli/src/commands/DecompressCommand.hpp
+++ b/src/mosqueeze-cli/src/commands/DecompressCommand.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <CLI/CLI.hpp>
+
+#include <string>
+
+namespace mosqueeze::cli {
+
+struct DecompressOptions {
+    std::string inputFile;
+    std::string outputFile;
+    bool jsonOutput = false;
+};
+
+void addDecompressCommand(CLI::App& app);
+int runDecompress(const DecompressOptions& opts);
+
+} // namespace mosqueeze::cli

--- a/src/mosqueeze-cli/src/main.cpp
+++ b/src/mosqueeze-cli/src/main.cpp
@@ -1,4 +1,6 @@
-﻿#include <CLI/CLI.hpp>
+#include "commands/CompressCommand.hpp"
+#include "commands/DecompressCommand.hpp"
+#include <CLI/CLI.hpp>
 #include <fmt/format.h>
 #include <fmt/ranges.h>
 #include <mosqueeze/AlgorithmSelector.hpp>
@@ -199,6 +201,8 @@ int main(int argc, char** argv) {
 
     addAnalyzeCommand(app);
     addSuggestCommand(app);
+    mosqueeze::cli::addCompressCommand(app);
+    mosqueeze::cli::addDecompressCommand(app);
 
     CLI11_PARSE(app, argc, argv);
 


### PR DESCRIPTION
Worker spec for #67 - CLI compress and decompress commands for TheVault integration.

## Overview
This spec defines the implementation for adding `compress` and `decompress` commands to mosqueeze-cli.

## Key Points
- Uses existing CompressionPipeline from libmosqueeze
- JSON output for programmatic use by TheVault
- Stdin/stdout support for piping
- All 4 algorithms supported (zstd, brotli, lzma, zpaq)
- Preprocessor selection for special file types

## Test Plan
- Unit tests for command parsing
- Integration tests for roundtrip compression
- JSON output validation

Depends on: #67