### PR TITLE
fix: add tag for main branch pushes in docker-server workflow

### DIFF
--- a/.github/workflows/docker-server.yml
+++ b/.github/workflows/docker-server.yml
@@ -67,6 +67,7 @@ jobs:
           tags: |
             type=ref,event=tag
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5


### PR DESCRIPTION
## Problem

When pushing to `main` branch, the `docker-server.yml` workflow fails with:
```
ERROR: failed to build: tag is needed when pushing to registry
```

The `docker/metadata-action` requires at least one tag when pushing. The existing configuration only generated tags for version tags (`v*`), not for main branch pushes.

## Solution

Added a tag rule for main branch pushes:
```yaml
type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
```

This ensures `ghcr.io/fathormb/mosqueeze-server:latest` is published on every merge to main.

## Testing

After merge, re-run the failed workflow on main branch.