### PR TITLE
fix(ci): resolve docker build timeout - default to amd64 only

### DIFF
--- a/.github/workflows/docker-server.yml
+++ b/.github/workflows/docker-server.yml
@@ -13,6 +13,11 @@ on:
         required: false
         default: true
         type: boolean
+      platforms:
+        description: 'Target platforms'
+        required: false
+        default: 'linux/amd64'
+        type: string
 
 env:
   REGISTRY: ghcr.io
@@ -46,6 +51,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up QEMU
+        if: ${{ contains(github.event.inputs.platforms || 'linux/amd64', 'linux/arm') }}
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
@@ -65,8 +71,8 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=ref,event=tag
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
 
       - name: Build and push Docker image
@@ -77,7 +83,7 @@ jobs:
           push: ${{ github.event_name != 'workflow_dispatch' || inputs.push }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ github.event.inputs.platforms || 'linux/amd64' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |


### PR DESCRIPTION
## Problem

Docker build was timing out after 6 hours due to:

1. **arm64 via QEMU emulation** - Extremely slow compilation of C++ with vcpkg/gRPC/Protobuf
2. **Tag generation broken** - `latest` tag not being created on main branch pushes
3. **QEMU setup unnecessary** when building amd64 only

## Changes

| Before | After |
|--------|-------|
| `platforms: linux/amd64,linux/arm64` | `platforms: linux/amd64` (default) |
| QEMU always setup | QEMU only when building arm |
| Broken tag logic | Proper semver + latest on main |

## Benefits

- **Build time**: From 6h timeout → ~15-30 min expected
- **Tags**: `latest` on main, `vX.Y.Z` on tag push
- **Flexibility**: Manual multi-platform via workflow_dispatch input

## Testing

After merge, push to main should complete within 30 minutes and produce:
- `ghcr.io/fathormb/mosqueeze-server:latest`

For manual arm64 build (when needed):
- Use workflow_dispatch with `platforms: linux/amd64,linux/arm64`

## Related

- Issue: https://github.com/fathorMB/MoSqueeze/issues/70