### PR TITLE
fix(ci): use format() for cache-to expression syntax

### DIFF
--- a/.github/workflows/docker-server.yml
+++ b/.github/workflows/docker-server.yml
@@ -92,7 +92,7 @@ jobs:
           cache-from: |
             type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache
             type=gha
-          cache-to: ${{ github.event.inputs.no_cache == 'true' && 'type=inline' || 'type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache,mode=max' }}
+          cache-to: ${{ github.event.inputs.no_cache == 'true' && 'type=inline' || format('type=registry,ref={0}/{1}:buildcache,mode=max', env.REGISTRY, env.IMAGE_NAME) }}
           provenance: true
           sbom: true
           build-args: |


### PR DESCRIPTION
## Summary
Fixes syntax error in `docker-server.yml` caused by nested `${{ }}` expressions in the `cache-to` parameter.

## Problem
Line 95 had invalid nested expression:
```yaml
cache-to: ${{ ... || 'type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache,mode=max' }}
```

GitHub Actions expressions cannot be nested like this.

## Solution
Use `format()` function:
```yaml
cache-to: ${{ github.event.inputs.no_cache == 'true' && 'type=inline' || format('type=registry,ref={0}/{1}:buildcache,mode=max', env.REGISTRY, env.IMAGE_NAME) }}
```

## Root Cause
PR #89 introduced this syntax error when merging the cache optimization. The build fails immediately at the "Build and push" step.

Fixes the build failure from run #24890309185
