### PR TITLE
fix(ci): lowercase cache refs for registry compatibility

### DIFF
--- a/.github/workflows/docker-server.yml
+++ b/.github/workflows/docker-server.yml
@@ -90,9 +90,9 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           platforms: ${{ github.event.inputs.platforms || 'linux/amd64' }}
           cache-from: |
-            type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache
+            type=registry,ref=${{ env.REGISTRY }}/${{ toLower(env.IMAGE_NAME) }}:buildcache
             type=gha
-          cache-to: ${{ github.event.inputs.no_cache == 'true' && 'type=inline' || format('type=registry,ref={0}/{1}:buildcache,mode=max', env.REGISTRY, env.IMAGE_NAME) }}
+          cache-to: ${{ github.event.inputs.no_cache == 'true' && 'type=inline' || format('type=registry,ref={0}/{1}:buildcache,mode=max', env.REGISTRY, toLower(env.IMAGE_NAME)) }}
           provenance: true
           sbom: true
           build-args: |


### PR DESCRIPTION
## Summary
Fixes registry cache error: `repository name must be lowercase`

## Problem
GitHub Container Registry requires lowercase image names for cache references. The workflow was using `fathorMB/mosqueeze-server` which caused:
```
ERROR: failed to configure registry cache exporter: invalid reference format: repository name (fathorMB/mosqueeze-server) must be lowercase
```

## Solution
Use `toLower()` for cache references:
```yaml
cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ toLower(env.IMAGE_NAME) }}:buildcache
cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ toLower(env.IMAGE_NAME) }}:buildcache,mode=max
```

This ensures the cache tags use lowercase `fathormb/mosqueeze-server` instead of `fathorMB/mosqueeze-server`.

## Related
- PR #90 fixed the first syntax error
- This PR fixes the lowercase requirement

Fixes run #24891220258