### PR TITLE
fix(ci): lowercase cache refs in docker-server-optimized.yml

### DIFF
--- a/.github/workflows/docker-server-optimized.yml
+++ b/.github/workflows/docker-server-optimized.yml
@@ -98,8 +98,8 @@ jobs:
           context: .
           file: ./src/mosqueeze-server/Dockerfile
           target: vcpkg-base
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:cache
-          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:cache,mode=max
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ toLower(env.IMAGE_NAME) }}:cache
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ toLower(env.IMAGE_NAME) }}:cache,mode=max
           platforms: ${{ github.event.inputs.platforms || 'linux/amd64' }}
           build-args: |
             MOSQUEEZE_VERSION=${{ github.ref_name }}
@@ -114,7 +114,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           platforms: ${{ github.event.inputs.platforms || 'linux/amd64' }}
           cache-from: |
-            type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:cache
+            type=registry,ref=${{ env.REGISTRY }}/${{ toLower(env.IMAGE_NAME) }}:cache
             type=gha
           cache-to: type=gha,mode=${{ github.event.inputs.no_cache == 'true' && 'min' || 'max' }}
           build-args: |
@@ -131,7 +131,7 @@ jobs:
           context: .
           file: ./src/mosqueeze-server/Dockerfile
           push: false
-          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:cache,mode=max
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ toLower(env.IMAGE_NAME) }}:cache,mode=max
           platforms: ${{ github.event.inputs.platforms || 'linux/amd64' }}
           build-args: |
             MOSQUEEZE_VERSION=${{ github.ref_name }}


### PR DESCRIPTION
## Fix
Same issue as PR #91 - GHCR requires lowercase repository names in cache references.

## Changes
Updated 4 cache-from/cache-to refs in `docker-server-optimized.yml` to use `toLower()`:

1. Line 101-102: vcpkg-base target cache refs
2. Line 117: Build and push cache-from
3. Line 134: Update registry cache step

## Why
The `docker-server-optimized.yml` workflow was also failing with:
```
ERROR: repository name (fathorMB/mosqueeze-server) must be lowercase
```

This workflow runs in parallel with `docker-server.yml` and needs the same fix.