### PR TITLE
fix(ci): lowercase image name for GHCR cache refs

### DIFF
--- a/.github/workflows/docker-server-optimized.yml
+++ b/.github/workflows/docker-server-optimized.yml
@@ -26,7 +26,6 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository_owner }}/mosqueeze-server
 
 jobs:
   check:
@@ -60,6 +59,13 @@ jobs:
       packages: write
 
     steps:
+      - name: Prepare image name (lowercase)
+        id: image
+        run: |
+          IMAGE_NAME="${{ github.repository_owner }}/mosqueeze-server"
+          IMAGE_NAME_LC=$(echo "$IMAGE_NAME" | tr '[:upper:]' '[:lower:]')
+          echo "image_name=$IMAGE_NAME_LC" >> $GITHUB_OUTPUT
+
       - name: Checkout repository
         uses: actions/checkout@v4
 
@@ -84,7 +90,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ steps.image.outputs.image_name }}
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
@@ -98,8 +104,8 @@ jobs:
           context: .
           file: ./src/mosqueeze-server/Dockerfile
           target: vcpkg-base
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ toLower(env.IMAGE_NAME) }}:cache
-          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ toLower(env.IMAGE_NAME) }}:cache,mode=max
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ steps.image.outputs.image_name }}:cache
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ steps.image.outputs.image_name }}:cache,mode=max
           platforms: ${{ github.event.inputs.platforms || 'linux/amd64' }}
           build-args: |
             MOSQUEEZE_VERSION=${{ github.ref_name }}
@@ -114,7 +120,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           platforms: ${{ github.event.inputs.platforms || 'linux/amd64' }}
           cache-from: |
-            type=registry,ref=${{ env.REGISTRY }}/${{ toLower(env.IMAGE_NAME) }}:cache
+            type=registry,ref=${{ env.REGISTRY }}/${{ steps.image.outputs.image_name }}:cache
             type=gha
           cache-to: type=gha,mode=${{ github.event.inputs.no_cache == 'true' && 'min' || 'max' }}
           build-args: |
@@ -131,7 +137,7 @@ jobs:
           context: .
           file: ./src/mosqueeze-server/Dockerfile
           push: false
-          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ toLower(env.IMAGE_NAME) }}:cache,mode=max
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ steps.image.outputs.image_name }}:cache,mode=max
           platforms: ${{ github.event.inputs.platforms || 'linux/amd64' }}
           build-args: |
             MOSQUEEZE_VERSION=${{ github.ref_name }}

--- a/.github/workflows/docker-server.yml
+++ b/.github/workflows/docker-server.yml
@@ -26,7 +26,8 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository_owner }}/mosqueeze-server
+  # Note: GHCR requires lowercase image names for cache refs
+  # IMAGE_NAME_LC is computed in the build job
 
 jobs:
   check:
@@ -52,6 +53,14 @@ jobs:
       packages: write
 
     steps:
+      - name: Prepare image name (lowercase)
+        id: image
+        run: |
+          # GHCR requires lowercase image names
+          IMAGE_NAME="${{ github.repository_owner }}/mosqueeze-server"
+          IMAGE_NAME_LC=$(echo "$IMAGE_NAME" | tr '[:upper:]' '[:lower:]')
+          echo "image_name=$IMAGE_NAME_LC" >> $GITHUB_OUTPUT
+
       - name: Checkout repository
         uses: actions/checkout@v4
 
@@ -74,7 +83,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ steps.image.outputs.image_name }}
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
@@ -90,9 +99,9 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           platforms: ${{ github.event.inputs.platforms || 'linux/amd64' }}
           cache-from: |
-            type=registry,ref=${{ env.REGISTRY }}/${{ toLower(env.IMAGE_NAME) }}:buildcache
+            type=registry,ref=${{ env.REGISTRY }}/${{ steps.image.outputs.image_name }}:buildcache
             type=gha
-          cache-to: ${{ github.event.inputs.no_cache == 'true' && 'type=inline' || format('type=registry,ref={0}/{1}:buildcache,mode=max', env.REGISTRY, toLower(env.IMAGE_NAME)) }}
+          cache-to: ${{ github.event.inputs.no_cache == 'true' && 'type=inline' || format('type=registry,ref={0}/{1}:buildcache,mode=max', env.REGISTRY, steps.image.outputs.image_name) }}
           provenance: true
           sbom: true
           build-args: |


### PR DESCRIPTION
## Fix
`toLower()` is NOT a valid GitHub Actions function. The workflow was marked as **invalid** because of the undefined toLower() expression.

## Solution
Added a bash step that computes the lowercase image name using `tr`:
```yaml
- name: Prepare image name (lowercase)
  id: image
  run: |
    IMAGE_NAME="${{ github.repository_owner }}/mosqueeze-server"
    IMAGE_NAME_LC=$(echo "$IMAGE_NAME" | tr '[:upper:]' '[:lower:]')
    echo "image_name=$IMAGE_NAME_LC" >> $GITHUB_OUTPUT
```

## Files Changed
- `.github/workflows/docker-server.yml` - Added lowercase step, updated all refs
- `.github/workflows/docker-server-optimized.yml` - Same fix

## Why this works
GHCR requires lowercase repository names in cache references:
```
ERROR: repository name (fathorMB/mosqueeze-server) must be lowercase
```

The bash approach is the standard way to handle this in GitHub Actions.