### PR TITLE
fix(ci): fix mosqueeze-server Docker build context paths

### DIFF
--- a/src/mosqueeze-server/Dockerfile
+++ b/src/mosqueeze-server/Dockerfile
@@ -39,9 +39,9 @@ WORKDIR /app
 # Copy source code (separate layer - only invalidates on code change)
 COPY CMakeLists.txt ./
 COPY src/ ./src/
-COPY include/ ./include/
 COPY cmake/ ./cmake/
 COPY tests/ ./tests/
+COPY third_party/ ./third_party/
 
 # Build application
 RUN cmake -B build -S . \


### PR DESCRIPTION
## Summary
- remove invalid `COPY include/ ./include/` from `src/mosqueeze-server/Dockerfile`
- add `COPY third_party/ ./third_party/` so root CMake can resolve `third_party/zpaq`

## Why
Recent Actions failures were caused by Docker build context mismatch:
- `/include` does not exist at repository root
- build failed before compile stage with `"/include": not found`

## Validation
- inspected failed workflow logs (`Build and Push mosqueeze-server Docker Image`)
- confirmed repo layout (`include/` missing, `third_party/` present)
- applied minimal Dockerfile fix to match actual repository structure
