### PR TITLE
fix(ci): avoid CMake configure in Docker vcpkg-base stage

### DIFF
--- a/src/mosqueeze-server/Dockerfile
+++ b/src/mosqueeze-server/Dockerfile
@@ -25,11 +25,8 @@ WORKDIR /app
 # Copy ONLY dependency manifests first (maximizes Docker layer cache)
 COPY vcpkg.json vcpkg-configuration.json* ./
 
-# Install dependencies - cached layer if vcpkg.json unchanged
-RUN cmake -B build-deps -S . \
-    -DCMAKE_TOOLCHAIN_FILE=${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake \
-    -DMOSQUEEZE_BUILD_SERVER=ON \
-    -DMOSQUEEZE_BUILD_TESTS=OFF \
+# Install dependencies in manifest mode (does not require CMakeLists.txt in /app)
+RUN ${VCPKG_ROOT}/vcpkg install --clean-after-build \
     && echo "Dependencies ready"
 
 FROM vcpkg-base AS build


### PR DESCRIPTION
## Summary
- replace the `vcpkg-base` dependency step in `src/mosqueeze-server/Dockerfile`
- use `vcpkg install --clean-after-build` (manifest mode) instead of `cmake -S .`

## Root Cause
Latest failing runs on `main` (for example: `24892380381`) fail in the cache stage with:
- `CMake Error: The source directory "/app" does not appear to contain CMakeLists.txt.`

That stage only copied `vcpkg.json` and then ran CMake configure, which requires `CMakeLists.txt`.

## Why this fix
Manifest-mode `vcpkg install` uses `vcpkg.json` directly and does not require the project sources/CMake files in that stage, preserving the intended cache optimization.
