### PR TITLE
fix(ci): resolve pinned vcpkg baseline in Docker builds

### DIFF
--- a/src/mosqueeze-server/Dockerfile
+++ b/src/mosqueeze-server/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 ENV VCPKG_ROOT=/opt/vcpkg
 ENV VCPKG_BINARY_SOURCES=clear
 
-RUN git clone --depth 1 https://github.com/microsoft/vcpkg.git ${VCPKG_ROOT} \
+RUN git clone https://github.com/microsoft/vcpkg.git ${VCPKG_ROOT} \
     && ${VCPKG_ROOT}/bootstrap-vcpkg.sh -disableMetrics
 
 WORKDIR /app


### PR DESCRIPTION
## Summary
- remove shallow clone (`--depth 1`) from `src/mosqueeze-server/Dockerfile` vcpkg bootstrap step

## Root cause
Current `main` Docker workflow fails during vcpkg manifest install with pinned baseline SHA from `vcpkg.json`:
- `builtin-baseline`: `63c3d813052467a5f117940f476b43f324df901b`
- error in CI: failed to `git show ... versions/baseline.json` for that commit

Because vcpkg repo was cloned shallowly, the baseline commit was unavailable inside the image.

## Why this fix
Fetching full vcpkg history guarantees the pinned baseline commit can be resolved during `vcpkg install` in Docker CI.
