### PR TITLE
fix: add docs directory to Docker build context

### DIFF
--- a/src/mosqueeze-server/Dockerfile
+++ b/src/mosqueeze-server/Dockerfile
@@ -39,6 +39,7 @@ COPY src/ ./src/
 COPY cmake/ ./cmake/
 COPY tests/ ./tests/
 COPY third_party/ ./third_party/
+COPY docs/ ./docs/
 
 # Build application
 RUN cmake -B build -S . \


### PR DESCRIPTION
## Problem

The Docker build for `mosqueeze-server` was failing with:
```
gmake[3]: *** No rule to make target '/app/docs/benchmarks/combined_decision_matrix.json', needed by 'src/libmosqueeze/decision_matrix_data.hpp'.  Stop.
```

## Root Cause

The Dockerfile did not copy the `docs/` directory, which contains `docs/benchmarks/combined_decision_matrix.json` required by the CMake build to generate the `decision_matrix_data.hpp` header.

## Fix

Added `COPY docs/ ./docs/` to the Dockerfile build stage.

## Testing

This PR will trigger the Docker workflow to verify the fix.