### PR TITLE
fix(docker): create vcpkg cache directory before install

### DIFF
--- a/src/mosqueeze-server/Dockerfile
+++ b/src/mosqueeze-server/Dockerfile
@@ -19,7 +19,8 @@ ENV VCPKG_ROOT=/opt/vcpkg
 ENV VCPKG_BINARY_SOURCES="x-archives,/root/.cache/vcpkg/archives,readwrite"
 
 RUN git clone https://github.com/microsoft/vcpkg.git ${VCPKG_ROOT} \
-    && ${VCPKG_ROOT}/bootstrap-vcpkg.sh -disableMetrics
+    && ${VCPKG_ROOT}/bootstrap-vcpkg.sh -disableMetrics \
+    && mkdir -p /root/.cache/vcpkg/archives
 
 WORKDIR /app
 


### PR DESCRIPTION
## Problem

Docker workflow `docker-publish.yml` fails with:
```
buildx failed with: ERROR: failed to build: failed to solve: 
process "/bin/sh -c ${VCPKG_ROOT}/vcpkg install --clean-after-build" 
did not complete successfully: exit code: 1
```

## Root Cause

The vcpkg binary cache directory `/root/.cache/vcpkg/archives` does not exist when `vcpkg install` runs. vcpkg tries to use the cache but fails because the directory is missing.

## Solution

Add `mkdir -p /root/.cache/vcpkg/archives` to the bootstrap step, ensuring the cache directory exists before vcpkg install runs.

## Changes

```dockerfile
RUN git clone https://github.com/microsoft/vcpkg.git ${VCPKG_ROOT} \
    && ${VCPKG_ROOT}/bootstrap-vcpkg.sh -disableMetrics \
    && mkdir -p /root/.cache/vcpkg/archives  # <-- NEW
```

## Testing

- This fix was applied to the Dockerfile that was already updated in PR #113
- The cache directory creation is a standard requirement for vcpkg binary caching

## Related

- Follow-up to #113 (vcpkg binary caching)
- Fixes failing Docker workflows on main branch